### PR TITLE
Fix Solhint interactive prompt blocking lint:fix commands

### DIFF
--- a/apps/e2e/project.json
+++ b/apps/e2e/project.json
@@ -20,6 +20,13 @@
         "cwd": "apps/e2e"
       }
     },
+    "lint:fix": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "eslint . --fix",
+        "cwd": "apps/e2e"
+      }
+    },
     "show-report": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/contracts/project.json
+++ b/libs/contracts/project.json
@@ -12,6 +12,14 @@
         "parallel": false
       }
     },
+    "lint:fix": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": ["pnpm eslint . --fix", "solhint 'src/**/*.sol' --fix --noPrompt"],
+        "cwd": "libs/contracts",
+        "parallel": false
+      }
+    },
     "lint-js": {
       "executor": "nx:run-commands",
       "options": {
@@ -36,7 +44,7 @@
     "lint-sol-fix": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "solhint 'src/**/*.sol' --fix",
+        "command": "solhint 'src/**/*.sol' --fix --noPrompt",
         "cwd": "libs/contracts"
       }
     },


### PR DESCRIPTION
## Summary
- Added `--noPrompt` flag to Solhint fix commands to prevent interactive prompts that block CI/automated workflows
- Added missing `lint:fix` target to e2e project for consistency with other projects

## Test plan
- [x] Verified `nx run contracts:lint:fix` runs without hanging on confirmation prompt
- [x] Confirmed Solhint fixes are applied automatically
- [x] All existing linting functionality remains intact