### PR TITLE
Fix React act() warnings in frontend tests

### DIFF
--- a/apps/frontend/src/components/Liquidity/AddLiquidity.spec.tsx
+++ b/apps/frontend/src/components/Liquidity/AddLiquidity.spec.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import { vi } from 'vitest';
 import { AddLiquidity } from './AddLiquidity';
 import { createMockContracts, mockContractAddresses } from '../../test-mocks';
@@ -46,7 +46,9 @@ describe('AddLiquidity', () => {
     const ethInput = getByPlaceholderText('Enter ETH amount');
     const tokenInput = getByPlaceholderText('Enter SIMP amount');
 
-    fireEvent.change(ethInput, { target: { value: '5' } });
+    act(() => {
+      fireEvent.change(ethInput, { target: { value: '5' } });
+    });
 
     // Pool ratio: 20 SIMP / 10 ETH = 2:1
     expect(tokenInput).toHaveValue(10);
@@ -57,7 +59,9 @@ describe('AddLiquidity', () => {
     const ethInput = getByPlaceholderText('Enter ETH amount');
     const tokenInput = getByPlaceholderText('Enter SIMP amount');
 
-    fireEvent.change(tokenInput, { target: { value: '10' } });
+    act(() => {
+      fireEvent.change(tokenInput, { target: { value: '10' } });
+    });
 
     // Pool ratio: 10 ETH / 20 SIMP = 1:2
     expect(ethInput).toHaveValue(5);
@@ -75,7 +79,9 @@ describe('AddLiquidity', () => {
     const ethInput = getByPlaceholderText('Enter ETH amount');
     const tokenInput = getByPlaceholderText('Enter SIMP amount');
 
-    fireEvent.change(ethInput, { target: { value: '5' } });
+    act(() => {
+      fireEvent.change(ethInput, { target: { value: '5' } });
+    });
 
     expect(tokenInput).toHaveDisplayValue('');
   });
@@ -93,7 +99,9 @@ describe('AddLiquidity', () => {
     const ethInput = getByPlaceholderText('Enter ETH amount');
     const button = getByRole('button', { name: 'Add Liquidity' });
 
-    fireEvent.change(ethInput, { target: { value: '5' } });
+    act(() => {
+      fireEvent.change(ethInput, { target: { value: '5' } });
+    });
 
     expect(button).toBeEnabled();
   });
@@ -105,8 +113,10 @@ describe('AddLiquidity', () => {
     const ethInput = getByPlaceholderText('Enter ETH amount');
     const button = getByRole('button', { name: 'Add Liquidity' });
 
-    fireEvent.change(ethInput, { target: { value: '5' } });
-    fireEvent.click(button);
+    act(() => {
+      fireEvent.change(ethInput, { target: { value: '5' } });
+      fireEvent.click(button);
+    });
 
     await waitFor(() => {
       expect(mockTokenContract.approve).toHaveBeenCalledWith(
@@ -129,10 +139,12 @@ describe('AddLiquidity', () => {
       <AddLiquidity {...defaultProps} />
     );
     const ethInput = getByPlaceholderText('Enter ETH amount');
-
-    fireEvent.change(ethInput, { target: { value: '5' } });
     const button = getByRole('button', { name: 'Add Liquidity' });
-    fireEvent.click(button);
+
+    act(() => {
+      fireEvent.change(ethInput, { target: { value: '5' } });
+      fireEvent.click(button);
+    });
 
     expect(getByRole('button', { name: 'Waiting...' })).toBeTruthy();
   });
@@ -146,10 +158,12 @@ describe('AddLiquidity', () => {
       <AddLiquidity {...defaultProps} />
     );
     const ethInput = getByPlaceholderText('Enter ETH amount');
-
-    fireEvent.change(ethInput, { target: { value: '5' } });
     const button = getByRole('button', { name: 'Add Liquidity' });
-    fireEvent.click(button);
+
+    act(() => {
+      fireEvent.change(ethInput, { target: { value: '5' } });
+      fireEvent.click(button);
+    });
 
     await waitFor(() => {
       expect(mockSetErrorMessage).toHaveBeenCalledWith(

--- a/apps/frontend/src/components/Liquidity/Liquidity.spec.tsx
+++ b/apps/frontend/src/components/Liquidity/Liquidity.spec.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 import { vi } from 'vitest';
 import { Liquidity } from './Liquidity';
 import { createMockContracts } from '../../test-mocks';
@@ -68,7 +68,9 @@ describe('Liquidity', () => {
       <Liquidity {...defaultProps} />
     );
     const removeTab = getByRole('button', { name: 'Remove' });
-    fireEvent.click(removeTab);
+    act(() => {
+      fireEvent.click(removeTab);
+    });
 
     expect(getByPlaceholderText('LP Tokens to Remove')).toBeTruthy();
     expect(getByRole('button', { name: 'Remove Liquidity' })).toBeTruthy();
@@ -80,11 +82,15 @@ describe('Liquidity', () => {
     );
 
     // Switch to remove
-    fireEvent.click(getByRole('button', { name: 'Remove' }));
+    act(() => {
+      fireEvent.click(getByRole('button', { name: 'Remove' }));
+    });
     expect(getByPlaceholderText('LP Tokens to Remove')).toBeTruthy();
 
     // Switch back to add
-    fireEvent.click(getByRole('button', { name: 'Add' }));
+    act(() => {
+      fireEvent.click(getByRole('button', { name: 'Add' }));
+    });
     expect(getByPlaceholderText('Enter ETH amount')).toBeTruthy();
   });
 });

--- a/apps/frontend/src/components/Liquidity/LiquidityHeader.spec.tsx
+++ b/apps/frontend/src/components/Liquidity/LiquidityHeader.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { LiquidityHeader } from './LiquidityHeader';
 
@@ -37,7 +37,9 @@ describe('LiquidityHeader Component', () => {
     render(<LiquidityHeader {...defaultProps} activeTab="add" />);
 
     const removeButton = screen.getByRole('button', { name: 'Remove' });
-    fireEvent.click(removeButton);
+    act(() => {
+      fireEvent.click(removeButton);
+    });
 
     expect(mockOnTabChange).toHaveBeenCalledWith('remove');
   });
@@ -56,7 +58,9 @@ describe('LiquidityHeader Component', () => {
     render(<LiquidityHeader {...defaultProps} disabled={true} />);
 
     const removeButton = screen.getByRole('button', { name: 'Remove' });
-    fireEvent.click(removeButton);
+    act(() => {
+      fireEvent.click(removeButton);
+    });
 
     expect(mockOnTabChange).not.toHaveBeenCalled();
   });

--- a/apps/frontend/src/components/Liquidity/RemoveLiquidity.spec.tsx
+++ b/apps/frontend/src/components/Liquidity/RemoveLiquidity.spec.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import { vi } from 'vitest';
 import { RemoveLiquidity } from './RemoveLiquidity';
 import { createMockContracts } from '../../test-mocks';
@@ -56,7 +56,9 @@ describe('RemoveLiquidity', () => {
     );
 
     const lpInput = getByPlaceholderText('LP Tokens to Remove');
-    fireEvent.change(lpInput, { target: { value: '2.5' } });
+    act(() => {
+      fireEvent.change(lpInput, { target: { value: '2.5' } });
+    });
 
     // 2.5 LP tokens out of 10 total = 25% of pool
     // 25% of 10 ETH = 2.5 ETH
@@ -70,7 +72,9 @@ describe('RemoveLiquidity', () => {
     );
 
     const lpInput = getByPlaceholderText('LP Tokens to Remove');
-    fireEvent.change(lpInput, { target: { value: '' } });
+    act(() => {
+      fireEvent.change(lpInput, { target: { value: '' } });
+    });
 
     expect(getByText('0.0000 SIMP + 0.0000 ETH')).toBeTruthy();
   });
@@ -81,7 +85,9 @@ describe('RemoveLiquidity', () => {
     );
 
     const lpInput = getByPlaceholderText('LP Tokens to Remove');
-    fireEvent.change(lpInput, { target: { value: '1.5' } });
+    act(() => {
+      fireEvent.change(lpInput, { target: { value: '1.5' } });
+    });
 
     // 1.5 LP tokens out of 10 total = 15% of pool
     // 15% of 20 SIMP = 3 SIMP
@@ -95,10 +101,12 @@ describe('RemoveLiquidity', () => {
     );
 
     const lpInput = getByPlaceholderText('LP Tokens to Remove');
-    fireEvent.change(lpInput, { target: { value: '2.5' } });
-
     const removeButton = getByRole('button', { name: 'Remove Liquidity' });
-    fireEvent.click(removeButton);
+
+    act(() => {
+      fireEvent.change(lpInput, { target: { value: '2.5' } });
+      fireEvent.click(removeButton);
+    });
 
     await waitFor(() => {
       expect(mockAmmContract.removeLiquidity).toHaveBeenCalledWith(
@@ -117,12 +125,16 @@ describe('RemoveLiquidity', () => {
     );
 
     const lpInput = getByPlaceholderText('LP Tokens to Remove');
-    fireEvent.change(lpInput, { target: { value: '2.5' } });
-
     const removeButton = getByRole('button', { name: 'Remove Liquidity' });
-    fireEvent.click(removeButton);
 
-    expect(getByRole('button', { name: 'Waiting...' })).toBeTruthy();
+    act(() => {
+      fireEvent.change(lpInput, { target: { value: '2.5' } });
+      fireEvent.click(removeButton);
+    });
+
+    await waitFor(() => {
+      expect(getByRole('button', { name: 'Waiting...' })).toBeTruthy();
+    });
   });
 
   it('should handle transaction errors', async () => {
@@ -135,10 +147,12 @@ describe('RemoveLiquidity', () => {
     );
 
     const lpInput = getByPlaceholderText('LP Tokens to Remove');
-    fireEvent.change(lpInput, { target: { value: '2.5' } });
-
     const removeButton = getByRole('button', { name: 'Remove Liquidity' });
-    fireEvent.click(removeButton);
+
+    act(() => {
+      fireEvent.change(lpInput, { target: { value: '2.5' } });
+      fireEvent.click(removeButton);
+    });
 
     await waitFor(() => {
       expect(mockSetErrorMessage).toHaveBeenCalledWith(
@@ -160,7 +174,9 @@ describe('RemoveLiquidity', () => {
     );
 
     const lpInput = getByPlaceholderText('LP Tokens to Remove');
-    fireEvent.change(lpInput, { target: { value: '10' } });
+    act(() => {
+      fireEvent.change(lpInput, { target: { value: '10' } });
+    });
 
     const removeButton = getByRole('button', { name: 'Remove Liquidity' });
     expect(removeButton).toBeDisabled();
@@ -181,7 +197,9 @@ describe('RemoveLiquidity', () => {
     );
 
     const lpInput = getByPlaceholderText('LP Tokens to Remove');
-    fireEvent.change(lpInput, { target: { value: '1' } });
+    act(() => {
+      fireEvent.change(lpInput, { target: { value: '1' } });
+    });
 
     // With zero total LP tokens, output should be zero
     expect(getByText('0.0000 SIMP + 0.0000 ETH')).toBeTruthy();

--- a/apps/frontend/src/components/shared/InputWithOutput.spec.tsx
+++ b/apps/frontend/src/components/shared/InputWithOutput.spec.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 import { vi } from 'vitest';
 import { InputWithOutput } from './InputWithOutput';
 
@@ -40,7 +40,9 @@ describe('InputWithOutput', () => {
     );
 
     const input = getByPlaceholderText('Enter amount');
-    fireEvent.change(input, { target: { value: '25' } });
+    act(() => {
+      fireEvent.change(input, { target: { value: '25' } });
+    });
 
     expect(mockOnChange).toHaveBeenCalledWith('25');
   });
@@ -92,7 +94,9 @@ describe('InputWithOutput', () => {
     );
 
     const input = getByPlaceholderText('Enter amount');
-    fireEvent.change(input, { target: { value: '100' } });
+    act(() => {
+      fireEvent.change(input, { target: { value: '100' } });
+    });
 
     expect(mockOnChange).not.toHaveBeenCalled();
   });

--- a/apps/frontend/src/components/shared/TabGroup.spec.tsx
+++ b/apps/frontend/src/components/shared/TabGroup.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { vi, describe, it, expect } from 'vitest';
 import { TabGroup } from './TabGroup';
 
@@ -41,7 +41,9 @@ describe('TabGroup Component', () => {
     render(<TabGroup {...defaultProps} />);
 
     const tab2 = screen.getByRole('button', { name: 'Tab 2' });
-    fireEvent.click(tab2);
+    act(() => {
+      fireEvent.click(tab2);
+    });
 
     expect(mockOnTabChange).toHaveBeenCalledWith('tab2');
   });
@@ -50,7 +52,9 @@ describe('TabGroup Component', () => {
     render(<TabGroup {...defaultProps} />);
 
     const activeTab = screen.getByRole('button', { name: 'Tab 1' });
-    fireEvent.click(activeTab);
+    act(() => {
+      fireEvent.click(activeTab);
+    });
 
     expect(mockOnTabChange).toHaveBeenCalledWith('tab1');
   });
@@ -98,7 +102,9 @@ describe('TabGroup Component', () => {
     render(<TabGroup {...propsWithDisabledTab} />);
 
     const disabledTab = screen.getByRole('button', { name: 'Tab 2' });
-    fireEvent.click(disabledTab);
+    act(() => {
+      fireEvent.click(disabledTab);
+    });
 
     expect(mockOnTabChange).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- Wrapped fireEvent calls that trigger state updates in act() to eliminate React warnings
- Combined sequential related actions (input change + button click) into single act() calls for better organization
- Added act import to all affected test files
- Ensured proper async state handling with waitFor() where appropriate

## Test plan
- [x] All 206 frontend tests pass without act() warnings
- [x] No breaking changes to existing test behavior
- [x] Linting passes successfully

## Files Changed
- `TabGroup.spec.tsx`: Wrapped 3 fireEvent.click calls
- `InputWithOutput.spec.tsx`: Wrapped 2 fireEvent.change calls  
- `LiquidityHeader.spec.tsx`: Wrapped 2 fireEvent.click calls
- `Liquidity.spec.tsx`: Wrapped 3 fireEvent.click calls
- `AddLiquidity.spec.tsx`: Wrapped 6 fireEvent calls and combined sequential actions
- `RemoveLiquidity.spec.tsx`: Wrapped 9 fireEvent calls and combined sequential actions

Fixes React testing warnings and ensures proper state update handling in tests.