### PR TITLE
Extract AMM calculations to centralized utility with BigInt precision

### DIFF
--- a/apps/e2e/src/amm-functionality.spec.ts
+++ b/apps/e2e/src/amm-functionality.spec.ts
@@ -165,8 +165,8 @@ test.describe('AMM Functionality', () => {
       await simpInput.fill('20');
 
       // Verify inputs are filled correctly
-      await expect(ethInput).toHaveValue('10');
-      await expect(simpInput).toHaveValue('20');
+      await expect(ethInput).toHaveValue('10.0');
+      await expect(simpInput).toHaveValue('20.0');
 
       // Click Add Liquidity button and track gas usage
       const addLiquidityButton = page.getByRole('button', {
@@ -224,7 +224,7 @@ test.describe('AMM Functionality', () => {
       await ethSwapInput.fill('1');
 
       // Verify the input is filled
-      await expect(ethSwapInput).toHaveValue('1');
+      await expect(ethSwapInput).toHaveValue('1.0');
 
       // Wait for SIMP output calculation to appear
       await expect(swapSection.locator('text=/≈.*SIMP/i')).toBeVisible({
@@ -285,7 +285,7 @@ test.describe('AMM Functionality', () => {
       await simpSwapInput.fill('1');
 
       // Verify the input is filled
-      await expect(simpSwapInput).toHaveValue('1');
+      await expect(simpSwapInput).toHaveValue('1.0');
 
       // Wait for ETH output calculation to appear
       await expect(swapSection.locator('text=/≈.*ETH/i')).toBeVisible({

--- a/apps/frontend/src/components/ConnectedDashboard/ConnectedDashboard.spec.tsx
+++ b/apps/frontend/src/components/ConnectedDashboard/ConnectedDashboard.spec.tsx
@@ -21,16 +21,16 @@ interface MockWalletInfoProps {
 interface MockSwapProps {
   ammContract: unknown;
   tokenContract: unknown;
-  poolEthReserve: number;
-  poolTokenReserve: number;
+  poolEthReserve: bigint;
+  poolTokenReserve: bigint;
   onSwapComplete: () => void;
 }
 
 interface MockLiquidityProps {
   ammContract: unknown;
   tokenContract: unknown;
-  poolEthReserve: number;
-  poolTokenReserve: number;
+  poolEthReserve: bigint;
+  poolTokenReserve: bigint;
   lpTokenBalances: {
     userLPTokens: number;
     totalLPTokens: number;
@@ -57,7 +57,8 @@ vi.mock('../Swap/Swap', () => ({
   }: MockSwapProps) => (
     <div data-testid="swap">
       <div>
-        Pool: {poolEthReserve.toFixed(4)} ETH / {poolTokenReserve.toFixed(4)}{' '}
+        Pool: {parseFloat(ethers.formatUnits(poolEthReserve, 18)).toFixed(4)}{' '}
+        ETH / {parseFloat(ethers.formatUnits(poolTokenReserve, 18)).toFixed(4)}{' '}
         SIMP
       </div>
       <button onClick={onSwapComplete}>Complete Swap</button>
@@ -74,7 +75,8 @@ vi.mock('../Liquidity/Liquidity', () => ({
   }: MockLiquidityProps) => (
     <div data-testid="liquidity">
       <div>
-        Pool: {poolEthReserve.toFixed(4)} ETH / {poolTokenReserve.toFixed(4)}{' '}
+        Pool: {parseFloat(ethers.formatUnits(poolEthReserve, 18)).toFixed(4)}{' '}
+        ETH / {parseFloat(ethers.formatUnits(poolTokenReserve, 18)).toFixed(4)}{' '}
         SIMP
       </div>
       <div>LP Tokens: {lpTokenBalances.userLPTokens.toFixed(4)}</div>
@@ -139,8 +141,8 @@ describe('ConnectedDashboard', () => {
     });
 
     mockGetPoolReserves.mockResolvedValue({
-      ethReserve: 10.0,
-      tokenReserve: 20.0,
+      ethReserve: BigInt(10e18),
+      tokenReserve: BigInt(20e18),
     });
 
     mockGetLiquidityBalances.mockResolvedValue({
@@ -318,8 +320,8 @@ describe('ConnectedDashboard', () => {
 
       mockGetWalletBalances.mockRejectedValue(new Error('Network error'));
       mockGetPoolReserves.mockResolvedValue({
-        ethReserve: 10.0,
-        tokenReserve: 20.0,
+        ethReserve: BigInt(10e18),
+        tokenReserve: BigInt(20e18),
       });
       mockGetLiquidityBalances.mockResolvedValue({
         userLPTokens: 5.0,

--- a/apps/frontend/src/components/ConnectedDashboard/ConnectedDashboard.tsx
+++ b/apps/frontend/src/components/ConnectedDashboard/ConnectedDashboard.tsx
@@ -24,8 +24,8 @@ const DashboardContent = () => {
     tokenBalance: 0,
   });
   const [poolReserves, setPoolReserves] = useState<PoolReserves>({
-    ethReserve: 0,
-    tokenReserve: 0,
+    ethReserve: 0n,
+    tokenReserve: 0n,
   });
   const [lpTokenBalances, setLpTokenBalances] = useState<LiquidityBalances>({
     userLPTokens: 0,
@@ -37,7 +37,7 @@ const DashboardContent = () => {
   const refreshAllBalances = useCallback(async () => {
     if (!signer || !ethereumProvider || !account) {
       setWalletBalances({ ethBalance: 0, tokenBalance: 0 });
-      setPoolReserves({ ethReserve: 0, tokenReserve: 0 });
+      setPoolReserves({ ethReserve: 0n, tokenReserve: 0n });
       setLpTokenBalances({
         userLPTokens: 0,
         totalLPTokens: 0,
@@ -103,8 +103,8 @@ const DashboardContent = () => {
 };
 
 interface ContractsSectionProps {
-  poolEthReserve: number;
-  poolTokenReserve: number;
+  poolEthReserve: bigint;
+  poolTokenReserve: bigint;
   lpTokenBalances: LiquidityBalances;
   onSwapComplete: () => Promise<void>;
   onLiquidityComplete: () => Promise<void>;

--- a/apps/frontend/src/components/Liquidity/AddLiquidity.spec.tsx
+++ b/apps/frontend/src/components/Liquidity/AddLiquidity.spec.tsx
@@ -18,8 +18,8 @@ const mockOnLiquidityComplete = vi.fn();
 const defaultProps = {
   ammContract,
   tokenContract,
-  poolEthReserve: 10.0,
-  poolTokenReserve: 20.0,
+  poolEthReserve: BigInt(10 * 1e18), // 10 ETH in wei
+  poolTokenReserve: BigInt(20 * 1e18), // 20 tokens in wei
   onLiquidityComplete: mockOnLiquidityComplete,
 };
 
@@ -70,8 +70,8 @@ describe('AddLiquidity', () => {
   it('should not auto-calculate when pool is empty', () => {
     const emptyPoolProps = {
       ...defaultProps,
-      poolEthReserve: 0.0,
-      poolTokenReserve: 0.0,
+      poolEthReserve: 0n,
+      poolTokenReserve: 0n,
     };
     const { getByPlaceholderText } = render(
       <AddLiquidity {...emptyPoolProps} />

--- a/apps/frontend/src/components/Liquidity/AddLiquidity.spec.tsx
+++ b/apps/frontend/src/components/Liquidity/AddLiquidity.spec.tsx
@@ -18,8 +18,8 @@ const mockOnLiquidityComplete = vi.fn();
 const defaultProps = {
   ammContract,
   tokenContract,
-  poolEthReserve: BigInt(10 * 1e18), // 10 ETH in wei
-  poolTokenReserve: BigInt(20 * 1e18), // 20 tokens in wei
+  poolEthReserve: BigInt(10e18), // 10 ETH in wei
+  poolTokenReserve: BigInt(20e18), // 20 tokens in wei
   onLiquidityComplete: mockOnLiquidityComplete,
 };
 
@@ -121,12 +121,12 @@ describe('AddLiquidity', () => {
     await waitFor(() => {
       expect(mockTokenContract.approve).toHaveBeenCalledWith(
         mockContractAddresses.ammPoolAddress,
-        BigInt(10 * 1e18)
+        BigInt(10e18)
       );
       expect(mockAmmContract.addLiquidity).toHaveBeenCalledWith(
-        BigInt(10 * 1e18),
-        BigInt(995e15), // 0.5% slippage protection applied to 1 ETH
-        { value: BigInt(5 * 1e18) }
+        BigInt(10e18),
+        BigInt(0.995e18), // 0.5% slippage protection applied to 1 ETH
+        { value: BigInt(5e18) }
       );
       expect(mockOnLiquidityComplete).toHaveBeenCalled();
     });

--- a/apps/frontend/src/components/Liquidity/AddLiquidity.tsx
+++ b/apps/frontend/src/components/Liquidity/AddLiquidity.tsx
@@ -14,6 +14,14 @@ import {
 } from '../../utils/ammCalculations';
 import styles from './AddLiquidity.module.scss';
 
+// Helper function to format BigInt amounts for input display (removes trailing zeros)
+const formatAmountForInput = (amount: bigint): string => {
+  if (amount === 0n) return '';
+  const formatted = ethers.formatUnits(amount, 18);
+  // Remove trailing zeros and unnecessary decimal point
+  return formatted.replace(/\.?0+$/, '');
+};
+
 interface AddLiquidityProps {
   ammContract: AMMPool;
   tokenContract: Token;
@@ -141,7 +149,7 @@ export const AddLiquidity = ({
           value={
             liquidityEthAmount === 0n
               ? 0
-              : parseFloat(ethers.formatUnits(liquidityEthAmount, 18))
+              : parseFloat(formatAmountForInput(liquidityEthAmount))
           }
           onChange={(value) => {
             const numValue = value || 0;
@@ -155,7 +163,7 @@ export const AddLiquidity = ({
           value={
             liquidityTokenAmount === 0n
               ? 0
-              : parseFloat(ethers.formatUnits(liquidityTokenAmount, 18))
+              : parseFloat(formatAmountForInput(liquidityTokenAmount))
           }
           onChange={(value) => {
             const numValue = value || 0;

--- a/apps/frontend/src/components/Liquidity/AddLiquidity.tsx
+++ b/apps/frontend/src/components/Liquidity/AddLiquidity.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { ethers } from 'ethers';
 import { Token, AMMPool } from '@typechain-types';
 import { LiquidityInput } from './LiquidityInput';
 import { useErrorMessage } from '../../contexts/ErrorMessageContext';
@@ -13,14 +12,6 @@ import {
   calculateRequiredEthAmount,
 } from '../../utils/ammCalculations';
 import styles from './AddLiquidity.module.scss';
-
-// Helper function to format BigInt amounts for input display (removes trailing zeros)
-const formatAmountForInput = (amount: bigint): string => {
-  if (amount === 0n) return '';
-  const formatted = ethers.formatUnits(amount, 18);
-  // Remove trailing zeros and unnecessary decimal point
-  return formatted.replace(/\.?0+$/, '');
-};
 
 interface AddLiquidityProps {
   ammContract: AMMPool;
@@ -72,9 +63,12 @@ export const AddLiquidity = ({
     }
   };
 
-  const handleEthAmountChange = (value: bigint) => {
-    setLiquidityEthAmount(value);
-    const correspondingTokenAmount = calculateCorrespondingAmount(value, true);
+  const handleEthAmountChange = (valueWei: bigint) => {
+    setLiquidityEthAmount(valueWei);
+    const correspondingTokenAmount = calculateCorrespondingAmount(
+      valueWei,
+      true
+    );
 
     const poolHasLiquidity = poolEthReserve > 0n && poolTokenReserve > 0n;
 
@@ -84,9 +78,12 @@ export const AddLiquidity = ({
     }
   };
 
-  const handleTokenAmountChange = (value: bigint) => {
-    setLiquidityTokenAmount(value);
-    const correspondingEthAmount = calculateCorrespondingAmount(value, false);
+  const handleTokenAmountChange = (valueWei: bigint) => {
+    setLiquidityTokenAmount(valueWei);
+    const correspondingEthAmount = calculateCorrespondingAmount(
+      valueWei,
+      false
+    );
 
     const poolHasLiquidity = poolEthReserve > 0n && poolTokenReserve > 0n;
 
@@ -146,31 +143,13 @@ export const AddLiquidity = ({
     <>
       <div className={styles.inputRow}>
         <LiquidityInput
-          value={
-            liquidityEthAmount === 0n
-              ? 0
-              : parseFloat(formatAmountForInput(liquidityEthAmount))
-          }
-          onChange={(value) => {
-            const numValue = value || 0;
-            handleEthAmountChange(
-              numValue === 0 ? 0n : ethers.parseUnits(numValue.toString(), 18)
-            );
-          }}
+          valueWei={liquidityEthAmount}
+          onChange={handleEthAmountChange}
           placeholder="Enter ETH amount"
         />
         <LiquidityInput
-          value={
-            liquidityTokenAmount === 0n
-              ? 0
-              : parseFloat(formatAmountForInput(liquidityTokenAmount))
-          }
-          onChange={(value) => {
-            const numValue = value || 0;
-            handleTokenAmountChange(
-              numValue === 0 ? 0n : ethers.parseUnits(numValue.toString(), 18)
-            );
-          }}
+          valueWei={liquidityTokenAmount}
+          onChange={handleTokenAmountChange}
           placeholder="Enter SIMP amount"
         />
       </div>

--- a/apps/frontend/src/components/Liquidity/AddLiquidity.tsx
+++ b/apps/frontend/src/components/Liquidity/AddLiquidity.tsx
@@ -41,11 +41,6 @@ export const AddLiquidity = ({
       return 0n;
     }
 
-    // If pool is empty, don't auto-calculate - let user set initial ratio
-    if (poolEthReserve === 0n || poolTokenReserve === 0n) {
-      return 0n;
-    }
-
     if (isEthInput) {
       // Calculate required token amount based on ETH input
       return calculateRequiredTokenAmount(
@@ -65,30 +60,30 @@ export const AddLiquidity = ({
 
   const handleEthAmountChange = (valueWei: bigint) => {
     setLiquidityEthAmount(valueWei);
-    const correspondingTokenAmount = calculateCorrespondingAmount(
-      valueWei,
-      true
-    );
 
     const poolHasLiquidity = poolEthReserve > 0n && poolTokenReserve > 0n;
 
     // If pool has liquidity, always update the other field (including clearing it)
     if (poolHasLiquidity) {
+      const correspondingTokenAmount = calculateCorrespondingAmount(
+        valueWei,
+        true
+      );
       setLiquidityTokenAmount(correspondingTokenAmount);
     }
   };
 
   const handleTokenAmountChange = (valueWei: bigint) => {
     setLiquidityTokenAmount(valueWei);
-    const correspondingEthAmount = calculateCorrespondingAmount(
-      valueWei,
-      false
-    );
 
     const poolHasLiquidity = poolEthReserve > 0n && poolTokenReserve > 0n;
 
     // If pool has liquidity, always update the other field (including clearing it)
     if (poolHasLiquidity) {
+      const correspondingEthAmount = calculateCorrespondingAmount(
+        valueWei,
+        false
+      );
       setLiquidityEthAmount(correspondingEthAmount);
     }
   };

--- a/apps/frontend/src/components/Liquidity/AddLiquidity.tsx
+++ b/apps/frontend/src/components/Liquidity/AddLiquidity.tsx
@@ -33,56 +33,33 @@ export const AddLiquidity = ({
   const [isLoading, setIsLoading] = useState(false);
   const { setErrorMessage } = useErrorMessage();
 
-  const calculateCorrespondingAmount = (
-    amount: bigint,
-    isEthInput: boolean
-  ): bigint => {
-    if (amount === 0n) {
-      return 0n;
-    }
-
-    if (isEthInput) {
-      // Calculate required token amount based on ETH input
-      return calculateRequiredTokenAmount(
-        amount,
-        poolEthReserve,
-        poolTokenReserve
-      );
-    } else {
-      // Calculate required ETH amount based on token input
-      return calculateRequiredEthAmount(
-        amount,
-        poolEthReserve,
-        poolTokenReserve
-      );
-    }
-  };
-
-  const handleEthAmountChange = (valueWei: bigint) => {
-    setLiquidityEthAmount(valueWei);
+  const handleEthAmountChange = (amountWei: bigint) => {
+    setLiquidityEthAmount(amountWei);
 
     const poolHasLiquidity = poolEthReserve > 0n && poolTokenReserve > 0n;
 
     // If pool has liquidity, always update the other field (including clearing it)
     if (poolHasLiquidity) {
-      const correspondingTokenAmount = calculateCorrespondingAmount(
-        valueWei,
-        true
+      const correspondingTokenAmount = calculateRequiredTokenAmount(
+        amountWei,
+        poolEthReserve,
+        poolTokenReserve
       );
       setLiquidityTokenAmount(correspondingTokenAmount);
     }
   };
 
-  const handleTokenAmountChange = (valueWei: bigint) => {
-    setLiquidityTokenAmount(valueWei);
+  const handleTokenAmountChange = (amountWei: bigint) => {
+    setLiquidityTokenAmount(amountWei);
 
     const poolHasLiquidity = poolEthReserve > 0n && poolTokenReserve > 0n;
 
     // If pool has liquidity, always update the other field (including clearing it)
     if (poolHasLiquidity) {
-      const correspondingEthAmount = calculateCorrespondingAmount(
-        valueWei,
-        false
+      const correspondingEthAmount = calculateRequiredEthAmount(
+        amountWei,
+        poolEthReserve,
+        poolTokenReserve
       );
       setLiquidityEthAmount(correspondingEthAmount);
     }
@@ -138,12 +115,12 @@ export const AddLiquidity = ({
     <>
       <div className={styles.inputRow}>
         <LiquidityInput
-          valueWei={liquidityEthAmount}
+          amountWei={liquidityEthAmount}
           onChange={handleEthAmountChange}
           placeholder="Enter ETH amount"
         />
         <LiquidityInput
-          valueWei={liquidityTokenAmount}
+          amountWei={liquidityTokenAmount}
           onChange={handleTokenAmountChange}
           placeholder="Enter SIMP amount"
         />

--- a/apps/frontend/src/components/Liquidity/DisabledAddLiquidity.tsx
+++ b/apps/frontend/src/components/Liquidity/DisabledAddLiquidity.tsx
@@ -6,13 +6,13 @@ export const DisabledAddLiquidity = () => {
     <>
       <div className={styles.inputRow}>
         <LiquidityInput
-          value={0}
+          valueWei={0n}
           onChange={() => {}}
           placeholder="Enter ETH amount"
           disabled={true}
         />
         <LiquidityInput
-          value={0}
+          valueWei={0n}
           onChange={() => {}}
           placeholder="Enter SIMP amount"
           disabled={true}

--- a/apps/frontend/src/components/Liquidity/DisabledAddLiquidity.tsx
+++ b/apps/frontend/src/components/Liquidity/DisabledAddLiquidity.tsx
@@ -6,13 +6,13 @@ export const DisabledAddLiquidity = () => {
     <>
       <div className={styles.inputRow}>
         <LiquidityInput
-          valueWei={0n}
+          amountWei={0n}
           onChange={() => {}}
           placeholder="Enter ETH amount"
           disabled={true}
         />
         <LiquidityInput
-          valueWei={0n}
+          amountWei={0n}
           onChange={() => {}}
           placeholder="Enter SIMP amount"
           disabled={true}

--- a/apps/frontend/src/components/Liquidity/DisabledRemoveLiquidity.tsx
+++ b/apps/frontend/src/components/Liquidity/DisabledRemoveLiquidity.tsx
@@ -7,7 +7,7 @@ export const DisabledRemoveLiquidity = () => {
   return (
     <>
       <InputWithOutput
-        value=""
+        amountWei={0n}
         onChange={() => {}}
         placeholder="LP Tokens to Remove"
         generateExpectedOutput={generateExpectedOutput}

--- a/apps/frontend/src/components/Liquidity/Liquidity.spec.tsx
+++ b/apps/frontend/src/components/Liquidity/Liquidity.spec.tsx
@@ -18,8 +18,8 @@ const mockOnLiquidityComplete = vi.fn();
 const defaultProps = {
   ammContract,
   tokenContract,
-  poolEthReserve: 10.0,
-  poolTokenReserve: 20.0,
+  poolEthReserve: BigInt(10 * 1e18), // 10 ETH in wei
+  poolTokenReserve: BigInt(20 * 1e18), // 20 tokens in wei
   lpTokenBalances: {
     userLPTokens: 5.0,
     totalLPTokens: 10.0,

--- a/apps/frontend/src/components/Liquidity/Liquidity.spec.tsx
+++ b/apps/frontend/src/components/Liquidity/Liquidity.spec.tsx
@@ -18,8 +18,8 @@ const mockOnLiquidityComplete = vi.fn();
 const defaultProps = {
   ammContract,
   tokenContract,
-  poolEthReserve: BigInt(10 * 1e18), // 10 ETH in wei
-  poolTokenReserve: BigInt(20 * 1e18), // 20 tokens in wei
+  poolEthReserve: BigInt(10e18), // 10 ETH in wei
+  poolTokenReserve: BigInt(20e18), // 20 tokens in wei
   lpTokenBalances: {
     userLPTokens: 5.0,
     totalLPTokens: 10.0,

--- a/apps/frontend/src/components/Liquidity/Liquidity.tsx
+++ b/apps/frontend/src/components/Liquidity/Liquidity.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { ethers } from 'ethers';
 import { Token, AMMPool } from '@typechain-types';
 import { LiquidityBalances } from '../../utils/balances';
 import { LiquidityHeader } from './LiquidityHeader';
@@ -11,8 +12,8 @@ export { DisabledLiquidity } from './DisabledLiquidity';
 interface LiquidityProps {
   ammContract: AMMPool;
   tokenContract: Token;
-  poolEthReserve: number;
-  poolTokenReserve: number;
+  poolEthReserve: bigint;
+  poolTokenReserve: bigint;
   lpTokenBalances: LiquidityBalances;
   onLiquidityComplete: () => void;
 }
@@ -30,8 +31,9 @@ export const Liquidity = ({
   const PoolBalances = () => (
     <div className={styles.poolBalances}>
       <p>
-        <strong>Pool Reserves:</strong> {poolTokenReserve.toFixed(4)} SIMP +{' '}
-        {poolEthReserve.toFixed(4)} ETH
+        <strong>Pool Reserves:</strong>{' '}
+        {parseFloat(ethers.formatUnits(poolTokenReserve, 18)).toFixed(4)} SIMP +{' '}
+        {parseFloat(ethers.formatUnits(poolEthReserve, 18)).toFixed(4)} ETH
       </p>
       {lpTokenBalances.userLPTokens > 0 && (
         <p>

--- a/apps/frontend/src/components/Liquidity/LiquidityInput.spec.tsx
+++ b/apps/frontend/src/components/Liquidity/LiquidityInput.spec.tsx
@@ -1,5 +1,6 @@
 import { render, fireEvent } from '@testing-library/react';
 import { vi } from 'vitest';
+import { ethers } from 'ethers';
 import { LiquidityInput } from './LiquidityInput';
 
 const mockSetErrorMessage = vi.fn();
@@ -12,7 +13,7 @@ vi.mock('../../contexts/ErrorMessageContext', () => ({
 
 describe('LiquidityInput', () => {
   const defaultProps = {
-    value: 0,
+    valueWei: 0n,
     onChange: vi.fn(),
     placeholder: 'Test placeholder',
   };
@@ -32,7 +33,10 @@ describe('LiquidityInput', () => {
 
   it('should display value when provided', () => {
     const { getByDisplayValue } = render(
-      <LiquidityInput {...defaultProps} value={10.5} />
+      <LiquidityInput
+        {...defaultProps}
+        valueWei={ethers.parseUnits('10.5', 18)}
+      />
     );
 
     expect(getByDisplayValue('10.5')).toBeTruthy();
@@ -40,14 +44,14 @@ describe('LiquidityInput', () => {
 
   it('should show empty string when value is 0', () => {
     const { getByPlaceholderText } = render(
-      <LiquidityInput {...defaultProps} value={0} />
+      <LiquidityInput {...defaultProps} valueWei={0n} />
     );
 
     const input = getByPlaceholderText('Test placeholder');
     expect(input).toHaveValue(null);
   });
 
-  it('should call onChange with numeric value', () => {
+  it('should call onChange with BigInt wei value', () => {
     const mockOnChange = vi.fn();
     const { getByPlaceholderText } = render(
       <LiquidityInput {...defaultProps} onChange={mockOnChange} />
@@ -56,19 +60,23 @@ describe('LiquidityInput', () => {
     const input = getByPlaceholderText('Test placeholder');
     fireEvent.input(input, { target: { value: '123.45' } });
 
-    expect(mockOnChange).toHaveBeenCalledWith(123.45);
+    expect(mockOnChange).toHaveBeenCalledWith(ethers.parseUnits('123.45', 18));
   });
 
   it('should handle empty input', () => {
     const mockOnChange = vi.fn();
     const { getByPlaceholderText } = render(
-      <LiquidityInput {...defaultProps} onChange={mockOnChange} value={5} />
+      <LiquidityInput
+        {...defaultProps}
+        onChange={mockOnChange}
+        valueWei={ethers.parseUnits('5', 18)}
+      />
     );
 
     const input = getByPlaceholderText('Test placeholder') as HTMLInputElement;
     fireEvent.input(input, { target: { value: '' } });
 
-    expect(mockOnChange).toHaveBeenCalledWith(0);
+    expect(mockOnChange).toHaveBeenCalledWith(0n);
   });
 
   it('should be disabled when disabled prop is true', () => {

--- a/apps/frontend/src/components/Liquidity/LiquidityInput.spec.tsx
+++ b/apps/frontend/src/components/Liquidity/LiquidityInput.spec.tsx
@@ -13,7 +13,7 @@ vi.mock('../../contexts/ErrorMessageContext', () => ({
 
 describe('LiquidityInput', () => {
   const defaultProps = {
-    valueWei: 0n,
+    amountWei: 0n,
     onChange: vi.fn(),
     placeholder: 'Test placeholder',
   };
@@ -35,7 +35,7 @@ describe('LiquidityInput', () => {
     const { getByDisplayValue } = render(
       <LiquidityInput
         {...defaultProps}
-        valueWei={ethers.parseUnits('10.5', 18)}
+        amountWei={ethers.parseUnits('10.5', 18)}
       />
     );
 
@@ -44,7 +44,7 @@ describe('LiquidityInput', () => {
 
   it('should show empty string when value is 0', () => {
     const { getByPlaceholderText } = render(
-      <LiquidityInput {...defaultProps} valueWei={0n} />
+      <LiquidityInput {...defaultProps} amountWei={0n} />
     );
 
     const input = getByPlaceholderText('Test placeholder');
@@ -69,7 +69,7 @@ describe('LiquidityInput', () => {
       <LiquidityInput
         {...defaultProps}
         onChange={mockOnChange}
-        valueWei={ethers.parseUnits('5', 18)}
+        amountWei={ethers.parseUnits('5', 18)}
       />
     );
 

--- a/apps/frontend/src/components/Liquidity/LiquidityInput.tsx
+++ b/apps/frontend/src/components/Liquidity/LiquidityInput.tsx
@@ -1,15 +1,24 @@
+import { ethers } from 'ethers';
 import { useErrorMessage } from '../../contexts/ErrorMessageContext';
 import styles from './InputField.module.scss';
 
+// Helper function to format BigInt amounts for input display (removes trailing zeros)
+const formatAmountForInput = (amount: bigint): string => {
+  if (amount === 0n) return '';
+  const formatted = ethers.formatUnits(amount, 18);
+  // Remove trailing zeros and unnecessary decimal point
+  return formatted.replace(/\.?0+$/, '');
+};
+
 interface LiquidityInputProps {
-  value: number;
-  onChange: (value: number) => void;
+  valueWei: bigint;
+  onChange: (valueWei: bigint) => void;
   placeholder: string;
   disabled?: boolean;
 }
 
 export const LiquidityInput = ({
-  value,
+  valueWei,
   onChange,
   placeholder,
   disabled = false,
@@ -21,20 +30,25 @@ export const LiquidityInput = ({
       <input
         type="number"
         step="0.01"
-        value={value === 0 ? '' : value.toString()}
+        value={formatAmountForInput(valueWei)}
         onChange={(e) => {
           if (disabled) return;
           const value = e.target.value;
           if (value === '') {
-            onChange(0);
+            onChange(0n);
             return;
           }
-          const numValue = Number(value);
+          const numValue = parseFloat(value);
           if (isNaN(numValue)) {
             setErrorMessage('Please enter a valid number');
             return;
           }
-          onChange(numValue);
+          try {
+            const weiValue = ethers.parseUnits(numValue.toString(), 18);
+            onChange(weiValue);
+          } catch {
+            setErrorMessage('Please enter a valid number');
+          }
         }}
         placeholder={placeholder}
         className={styles.input}

--- a/apps/frontend/src/components/Liquidity/LiquidityInput.tsx
+++ b/apps/frontend/src/components/Liquidity/LiquidityInput.tsx
@@ -2,14 +2,6 @@ import { ethers } from 'ethers';
 import { useErrorMessage } from '../../contexts/ErrorMessageContext';
 import styles from './InputField.module.scss';
 
-// Helper function to format BigInt amounts for input display (removes trailing zeros)
-const formatAmountForInput = (amount: bigint): string => {
-  if (amount === 0n) return '';
-  const formatted = ethers.formatUnits(amount, 18);
-  // Remove trailing zeros and unnecessary decimal point
-  return formatted.replace(/\.?0+$/, '');
-};
-
 interface LiquidityInputProps {
   valueWei: bigint;
   onChange: (valueWei: bigint) => void;
@@ -30,7 +22,7 @@ export const LiquidityInput = ({
       <input
         type="number"
         step="0.01"
-        value={formatAmountForInput(valueWei)}
+        value={valueWei === 0n ? '' : ethers.formatUnits(valueWei, 18)}
         onChange={(e) => {
           if (disabled) return;
           const value = e.target.value;

--- a/apps/frontend/src/components/Liquidity/LiquidityInput.tsx
+++ b/apps/frontend/src/components/Liquidity/LiquidityInput.tsx
@@ -3,14 +3,14 @@ import { useErrorMessage } from '../../contexts/ErrorMessageContext';
 import styles from './InputField.module.scss';
 
 interface LiquidityInputProps {
-  valueWei: bigint;
-  onChange: (valueWei: bigint) => void;
+  amountWei: bigint;
+  onChange: (amountWei: bigint) => void;
   placeholder: string;
   disabled?: boolean;
 }
 
 export const LiquidityInput = ({
-  valueWei,
+  amountWei,
   onChange,
   placeholder,
   disabled = false,
@@ -22,7 +22,7 @@ export const LiquidityInput = ({
       <input
         type="number"
         step="0.01"
-        value={valueWei === 0n ? '' : ethers.formatUnits(valueWei, 18)}
+        value={amountWei === 0n ? '' : ethers.formatUnits(amountWei, 18)}
         onChange={(e) => {
           if (disabled) return;
           const value = e.target.value;

--- a/apps/frontend/src/components/Liquidity/LiquidityInput.tsx
+++ b/apps/frontend/src/components/Liquidity/LiquidityInput.tsx
@@ -30,13 +30,8 @@ export const LiquidityInput = ({
             onChange(0n);
             return;
           }
-          const numValue = parseFloat(value);
-          if (isNaN(numValue)) {
-            setErrorMessage('Please enter a valid number');
-            return;
-          }
           try {
-            const weiValue = ethers.parseUnits(numValue.toString(), 18);
+            const weiValue = ethers.parseUnits(value, 18);
             onChange(weiValue);
           } catch {
             setErrorMessage('Please enter a valid number');

--- a/apps/frontend/src/components/Liquidity/RemoveLiquidity.spec.tsx
+++ b/apps/frontend/src/components/Liquidity/RemoveLiquidity.spec.tsx
@@ -16,8 +16,8 @@ const mockOnLiquidityComplete = vi.fn();
 
 const defaultProps = {
   ammContract,
-  poolEthReserve: BigInt(10 * 1e18), // 10 ETH in wei
-  poolTokenReserve: BigInt(20 * 1e18), // 20 tokens in wei
+  poolEthReserve: BigInt(10e18), // 10 ETH in wei
+  poolTokenReserve: BigInt(20e18), // 20 tokens in wei
   lpTokenBalances: {
     userLPTokens: 5.0,
     totalLPTokens: 10.0,
@@ -110,9 +110,9 @@ describe('RemoveLiquidity', () => {
 
     await waitFor(() => {
       expect(mockAmmContract.removeLiquidity).toHaveBeenCalledWith(
-        BigInt(2.5 * 1e18),
-        BigInt(995e15), // 0.5% slippage protection applied
-        BigInt(995e15) // 0.5% slippage protection applied
+        BigInt(2.5e18),
+        BigInt(0.995e18), // 0.5% slippage protection applied
+        BigInt(0.995e18) // 0.5% slippage protection applied
       );
       expect(mockOnLiquidityComplete).toHaveBeenCalled();
     });

--- a/apps/frontend/src/components/Liquidity/RemoveLiquidity.spec.tsx
+++ b/apps/frontend/src/components/Liquidity/RemoveLiquidity.spec.tsx
@@ -16,8 +16,8 @@ const mockOnLiquidityComplete = vi.fn();
 
 const defaultProps = {
   ammContract,
-  poolEthReserve: 10.0,
-  poolTokenReserve: 20.0,
+  poolEthReserve: BigInt(10 * 1e18), // 10 ETH in wei
+  poolTokenReserve: BigInt(20 * 1e18), // 20 tokens in wei
   lpTokenBalances: {
     userLPTokens: 5.0,
     totalLPTokens: 10.0,

--- a/apps/frontend/src/components/Liquidity/RemoveLiquidity.tsx
+++ b/apps/frontend/src/components/Liquidity/RemoveLiquidity.tsx
@@ -14,8 +14,8 @@ import styles from './RemoveLiquidity.module.scss';
 
 interface RemoveLiquidityProps {
   ammContract: AMMPool;
-  poolEthReserve: number;
-  poolTokenReserve: number;
+  poolEthReserve: bigint;
+  poolTokenReserve: bigint;
   lpTokenBalances: LiquidityBalances;
   onLiquidityComplete: () => void;
 }
@@ -69,7 +69,7 @@ export const RemoveLiquidity = ({
   const generateExpectedOutput = createRemoveLiquidityOutputCalculator(
     poolEthReserve,
     poolTokenReserve,
-    lpTokenBalances.totalLPTokens
+    ethers.parseUnits(lpTokenBalances.totalLPTokens.toString(), 18)
   );
 
   return (

--- a/apps/frontend/src/components/Swap/DisabledSwap.spec.tsx
+++ b/apps/frontend/src/components/Swap/DisabledSwap.spec.tsx
@@ -51,8 +51,8 @@ describe('DisabledSwap Component', () => {
   it('should show expected output calculation', () => {
     render(
       <DisabledSwap
-        poolEthReserve={BigInt(10 * 1e18)}
-        poolTokenReserve={BigInt(20 * 1e18)}
+        poolEthReserve={BigInt(10e18)}
+        poolTokenReserve={BigInt(20e18)}
       />
     );
 

--- a/apps/frontend/src/components/Swap/DisabledSwap.spec.tsx
+++ b/apps/frontend/src/components/Swap/DisabledSwap.spec.tsx
@@ -57,6 +57,6 @@ describe('DisabledSwap Component', () => {
     );
 
     // Should show expected output with specific calculation result
-    expect(screen.getByText(/1 SIMP ≈ 0.500000 ETH/)).toBeInTheDocument();
+    expect(screen.getByText(/1 SIMP ≈ 0.5000 ETH/)).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/Swap/DisabledSwap.spec.tsx
+++ b/apps/frontend/src/components/Swap/DisabledSwap.spec.tsx
@@ -49,7 +49,12 @@ describe('DisabledSwap Component', () => {
   });
 
   it('should show expected output calculation', () => {
-    render(<DisabledSwap poolEthReserve={10} poolTokenReserve={20} />);
+    render(
+      <DisabledSwap
+        poolEthReserve={BigInt(10 * 1e18)}
+        poolTokenReserve={BigInt(20 * 1e18)}
+      />
+    );
 
     // Should show expected output with specific calculation result
     expect(screen.getByText(/1 SIMP ≈ 0.500000 ETH/)).toBeInTheDocument();

--- a/apps/frontend/src/components/Swap/DisabledSwap.tsx
+++ b/apps/frontend/src/components/Swap/DisabledSwap.tsx
@@ -29,7 +29,7 @@ export const DisabledSwap = ({
       </div>
       <SwapInput
         key="token-to-eth"
-        value=""
+        amountWei={0n}
         onChange={() => {}}
         placeholder="SIMP → ETH"
         onClick={() => {}}

--- a/apps/frontend/src/components/Swap/DisabledSwap.tsx
+++ b/apps/frontend/src/components/Swap/DisabledSwap.tsx
@@ -4,13 +4,13 @@ import { createSwapOutputCalculator } from '../../utils/expectedOutputCalculator
 import styles from './Swap.module.scss';
 
 interface DisabledSwapProps {
-  poolEthReserve?: number;
-  poolTokenReserve?: number;
+  poolEthReserve?: bigint;
+  poolTokenReserve?: bigint;
 }
 
 export const DisabledSwap = ({
-  poolEthReserve = 0,
-  poolTokenReserve = 0,
+  poolEthReserve = 0n,
+  poolTokenReserve = 0n,
 }: DisabledSwapProps) => {
   return (
     <div className={styles.swap}>

--- a/apps/frontend/src/components/Swap/Swap.spec.tsx
+++ b/apps/frontend/src/components/Swap/Swap.spec.tsx
@@ -24,8 +24,8 @@ const mockOnSwapComplete = vi.fn();
 const defaultProps = {
   ammContract,
   tokenContract,
-  poolEthReserve: 10.0,
-  poolTokenReserve: 20.0,
+  poolEthReserve: BigInt(10 * 1e18), // 10 ETH in wei
+  poolTokenReserve: BigInt(20 * 1e18), // 20 tokens in wei
   onSwapComplete: mockOnSwapComplete,
 };
 
@@ -64,9 +64,9 @@ describe('Swap Component', () => {
       const input = screen.getByPlaceholderText('SIMP → ETH');
       fireEvent.change(input, { target: { value: '5' } });
 
-      // With pool reserves ETH: 10, Token: 20
-      // Expected output: (10 * 5) / (20 + 5) = 2.000000
-      expect(screen.getByText(/≈ 2\.000000 ETH/)).toBeInTheDocument();
+      // With pool reserves ETH: 10, Token: 20 and 0.3% fee
+      // AMM formula: (10 * (5 * 997 / 1000)) / (20 + (5 * 997 / 1000)) ≈ 1.995197
+      expect(screen.getByText(/≈ 1\.995197 ETH/)).toBeInTheDocument();
     });
 
     it('should calculate ETH to Token swap correctly', () => {
@@ -78,14 +78,14 @@ describe('Swap Component', () => {
       const input = screen.getByPlaceholderText('ETH → SIMP');
       fireEvent.change(input, { target: { value: '2' } });
 
-      // With pool reserves ETH: 10, Token: 20
-      // Expected output: (20 * 2) / (10 + 2) = 3.333333
-      expect(screen.getByText(/≈ 3\.333333 SIMP/)).toBeInTheDocument();
+      // With pool reserves ETH: 10, Token: 20 and 0.3% fee
+      // AMM formula: (20 * (2 * 997 / 1000)) / (10 + (2 * 997 / 1000)) ≈ 3.324996
+      expect(screen.getByText(/≈ 3\.324996 SIMP/)).toBeInTheDocument();
     });
 
     it('should handle zero pool reserves', () => {
       render(
-        <Swap {...defaultProps} poolEthReserve={0} poolTokenReserve={0} />
+        <Swap {...defaultProps} poolEthReserve={0n} poolTokenReserve={0n} />
       );
 
       const input = screen.getByPlaceholderText('SIMP → ETH');
@@ -288,7 +288,7 @@ describe('Swap Component', () => {
       // Start with Token to ETH (default)
       const tokenInput = screen.getByPlaceholderText('SIMP → ETH');
       fireEvent.change(tokenInput, { target: { value: '5' } });
-      expect(screen.getByText(/≈ 2\.000000 ETH/)).toBeInTheDocument();
+      expect(screen.getByText(/≈ 1\.995197 ETH/)).toBeInTheDocument();
 
       // Switch to ETH to Token
       const simpTab = screen.getByRole('button', { name: 'SIMP' });
@@ -296,7 +296,7 @@ describe('Swap Component', () => {
 
       const ethInput = screen.getByPlaceholderText('ETH → SIMP');
       fireEvent.change(ethInput, { target: { value: '1' } });
-      expect(screen.getByText(/≈ 1\.818182 SIMP/)).toBeInTheDocument();
+      expect(screen.getByText(/≈ 1\.813222 SIMP/)).toBeInTheDocument();
     });
   });
 });

--- a/apps/frontend/src/components/Swap/Swap.spec.tsx
+++ b/apps/frontend/src/components/Swap/Swap.spec.tsx
@@ -24,8 +24,8 @@ const mockOnSwapComplete = vi.fn();
 const defaultProps = {
   ammContract,
   tokenContract,
-  poolEthReserve: BigInt(10 * 1e18), // 10 ETH in wei
-  poolTokenReserve: BigInt(20 * 1e18), // 20 tokens in wei
+  poolEthReserve: BigInt(10e18), // 10 ETH in wei
+  poolTokenReserve: BigInt(20e18), // 20 tokens in wei
   onSwapComplete: mockOnSwapComplete,
 };
 
@@ -126,8 +126,8 @@ describe('Swap Component', () => {
         expect(mockTokenContract.approve).toHaveBeenCalled();
         expect(mockAmmContract.swap).toHaveBeenCalledWith(
           mockContractAddresses.tokenAddress,
-          BigInt(1.5 * 1e18), // 1.5 SIMP in wei
-          BigInt(995e15) // 0.5% slippage protection applied
+          BigInt(1.5e18), // 1.5 SIMP in wei
+          BigInt(0.995e18) // 0.5% slippage protection applied
         );
       });
 
@@ -187,7 +187,7 @@ describe('Swap Component', () => {
           ethers.ZeroAddress,
           0,
           BigInt('995000000000000000'), // 0.5% slippage protection applied
-          { value: BigInt(1.5 * 1e18) } // 1.5 ETH in wei
+          { value: BigInt(1.5e18) } // 1.5 ETH in wei
         );
       });
 

--- a/apps/frontend/src/components/Swap/Swap.spec.tsx
+++ b/apps/frontend/src/components/Swap/Swap.spec.tsx
@@ -65,8 +65,8 @@ describe('Swap Component', () => {
       fireEvent.change(input, { target: { value: '5' } });
 
       // With pool reserves ETH: 10, Token: 20 and 0.3% fee
-      // AMM formula: (10 * (5 * 997 / 1000)) / (20 + (5 * 997 / 1000)) ≈ 1.995197
-      expect(screen.getByText(/≈ 1\.995197 ETH/)).toBeInTheDocument();
+      // AMM formula: (10 * (5 * 997 / 1000)) / (20 + (5 * 997 / 1000)) ≈ 1.9952
+      expect(screen.getByText(/≈ 1\.9952 ETH/)).toBeInTheDocument();
     });
 
     it('should calculate ETH to Token swap correctly', () => {
@@ -79,8 +79,8 @@ describe('Swap Component', () => {
       fireEvent.change(input, { target: { value: '2' } });
 
       // With pool reserves ETH: 10, Token: 20 and 0.3% fee
-      // AMM formula: (20 * (2 * 997 / 1000)) / (10 + (2 * 997 / 1000)) ≈ 3.324996
-      expect(screen.getByText(/≈ 3\.324996 SIMP/)).toBeInTheDocument();
+      // AMM formula: (20 * (2 * 997 / 1000)) / (10 + (2 * 997 / 1000)) ≈ 3.3250
+      expect(screen.getByText(/≈ 3\.3250 SIMP/)).toBeInTheDocument();
     });
 
     it('should handle zero pool reserves', () => {
@@ -100,7 +100,7 @@ describe('Swap Component', () => {
       const input = screen.getByPlaceholderText('SIMP → ETH');
       fireEvent.change(input, { target: { value: 'invalid' } });
 
-      expect(screen.getByText('1 SIMP ≈ 0.500000 ETH')).toBeInTheDocument();
+      expect(screen.getByText('1 SIMP ≈ 0.5000 ETH')).toBeInTheDocument();
     });
   });
 
@@ -288,7 +288,7 @@ describe('Swap Component', () => {
       // Start with Token to ETH (default)
       const tokenInput = screen.getByPlaceholderText('SIMP → ETH');
       fireEvent.change(tokenInput, { target: { value: '5' } });
-      expect(screen.getByText(/≈ 1\.995197 ETH/)).toBeInTheDocument();
+      expect(screen.getByText(/≈ 1\.9952 ETH/)).toBeInTheDocument();
 
       // Switch to ETH to Token
       const simpTab = screen.getByRole('button', { name: 'SIMP' });
@@ -296,7 +296,7 @@ describe('Swap Component', () => {
 
       const ethInput = screen.getByPlaceholderText('ETH → SIMP');
       fireEvent.change(ethInput, { target: { value: '1' } });
-      expect(screen.getByText(/≈ 1\.813222 SIMP/)).toBeInTheDocument();
+      expect(screen.getByText(/≈ 1\.8132 SIMP/)).toBeInTheDocument();
     });
   });
 });

--- a/apps/frontend/src/components/Swap/Swap.tsx
+++ b/apps/frontend/src/components/Swap/Swap.tsx
@@ -22,14 +22,6 @@ interface SwapProps {
   onSwapComplete: () => void;
 }
 
-// Helper function to format BigInt amounts for input display (removes trailing zeros)
-const formatAmountForInput = (amount: bigint): string => {
-  if (amount === 0n) return '';
-  const formatted = ethers.formatUnits(amount, 18);
-  // Remove trailing zeros and unnecessary decimal point
-  return formatted.replace(/\.?0+$/, '');
-};
-
 export const Swap = ({
   ammContract,
   tokenContract,
@@ -140,7 +132,7 @@ export const Swap = ({
       {swapDirection === 'token-to-eth' ? (
         <SwapInput
           key="token-to-eth"
-          value={formatAmountForInput(tokenAmount)}
+          value={tokenAmount === 0n ? '' : ethers.formatUnits(tokenAmount, 18)}
           onChange={(value) => {
             const numValue = parseFloat(value || '0');
             setTokenAmount(
@@ -161,7 +153,7 @@ export const Swap = ({
       ) : (
         <SwapInput
           key="eth-to-token"
-          value={formatAmountForInput(ethAmount)}
+          value={ethAmount === 0n ? '' : ethers.formatUnits(ethAmount, 18)}
           onChange={(value) => {
             const numValue = parseFloat(value || '0');
             setEthAmount(

--- a/apps/frontend/src/components/Swap/Swap.tsx
+++ b/apps/frontend/src/components/Swap/Swap.tsx
@@ -22,6 +22,14 @@ interface SwapProps {
   onSwapComplete: () => void;
 }
 
+// Helper function to format BigInt amounts for input display (removes trailing zeros)
+const formatAmountForInput = (amount: bigint): string => {
+  if (amount === 0n) return '';
+  const formatted = ethers.formatUnits(amount, 18);
+  // Remove trailing zeros and unnecessary decimal point
+  return formatted.replace(/\.?0+$/, '');
+};
+
 export const Swap = ({
   ammContract,
   tokenContract,
@@ -132,7 +140,7 @@ export const Swap = ({
       {swapDirection === 'token-to-eth' ? (
         <SwapInput
           key="token-to-eth"
-          value={tokenAmount === 0n ? '' : ethers.formatUnits(tokenAmount, 18)}
+          value={formatAmountForInput(tokenAmount)}
           onChange={(value) => {
             const numValue = parseFloat(value || '0');
             setTokenAmount(
@@ -153,7 +161,7 @@ export const Swap = ({
       ) : (
         <SwapInput
           key="eth-to-token"
-          value={ethAmount === 0n ? '' : ethers.formatUnits(ethAmount, 18)}
+          value={formatAmountForInput(ethAmount)}
           onChange={(value) => {
             const numValue = parseFloat(value || '0');
             setEthAmount(

--- a/apps/frontend/src/components/Swap/Swap.tsx
+++ b/apps/frontend/src/components/Swap/Swap.tsx
@@ -132,13 +132,8 @@ export const Swap = ({
       {swapDirection === 'token-to-eth' ? (
         <SwapInput
           key="token-to-eth"
-          value={tokenAmount === 0n ? '' : ethers.formatUnits(tokenAmount, 18)}
-          onChange={(value) => {
-            const numValue = parseFloat(value || '0');
-            setTokenAmount(
-              isNaN(numValue) ? 0n : ethers.parseUnits(numValue.toString(), 18)
-            );
-          }}
+          amountWei={tokenAmount}
+          onChange={setTokenAmount}
           placeholder="SIMP → ETH"
           onClick={swapTokensForETH}
           buttonText="Swap SIMP for ETH"
@@ -153,13 +148,8 @@ export const Swap = ({
       ) : (
         <SwapInput
           key="eth-to-token"
-          value={ethAmount === 0n ? '' : ethers.formatUnits(ethAmount, 18)}
-          onChange={(value) => {
-            const numValue = parseFloat(value || '0');
-            setEthAmount(
-              isNaN(numValue) ? 0n : ethers.parseUnits(numValue.toString(), 18)
-            );
-          }}
+          amountWei={ethAmount}
+          onChange={setEthAmount}
           placeholder="ETH → SIMP"
           onClick={swapETHForTokens}
           buttonText="Swap ETH for SIMP"

--- a/apps/frontend/src/components/Swap/Swap.tsx
+++ b/apps/frontend/src/components/Swap/Swap.tsx
@@ -17,8 +17,8 @@ export { DisabledSwap } from './DisabledSwap';
 interface SwapProps {
   ammContract: AMMPool;
   tokenContract: Token;
-  poolEthReserve: number;
-  poolTokenReserve: number;
+  poolEthReserve: bigint;
+  poolTokenReserve: bigint;
   onSwapComplete: () => void;
 }
 
@@ -29,8 +29,8 @@ export const Swap = ({
   poolTokenReserve,
   onSwapComplete,
 }: SwapProps) => {
-  const [ethAmount, setEthAmount] = useState<string>('');
-  const [tokenAmount, setTokenAmount] = useState<string>('');
+  const [ethAmount, setEthAmount] = useState<bigint>(0n);
+  const [tokenAmount, setTokenAmount] = useState<bigint>(0n);
   const [isLoading, setIsLoading] = useState(false);
   const [swapDirection, setSwapDirection] = useState<
     'eth-to-token' | 'token-to-eth'
@@ -39,13 +39,13 @@ export const Swap = ({
 
   // Clear amounts when direction changes
   useEffect(() => {
-    setEthAmount('');
-    setTokenAmount('');
+    setEthAmount(0n);
+    setTokenAmount(0n);
   }, [swapDirection]);
 
   const resetForm = () => {
-    setEthAmount('');
-    setTokenAmount('');
+    setEthAmount(0n);
+    setTokenAmount(0n);
   };
 
   const executeSwapTransaction = async (callback: () => Promise<void>) => {
@@ -72,40 +72,40 @@ export const Swap = ({
   };
 
   const swapETHForTokens = async () => {
-    if (!ethAmount) return;
+    if (ethAmount === 0n) return;
 
     await executeSwapTransaction(async () => {
       // Get expected output from contract and apply slippage protection
       const expectedOutput = await ammContract.getSwapOutput(
         ethers.ZeroAddress,
-        ethers.parseEther(ethAmount)
+        ethAmount
       );
       const minAmountOut = calculateMinAmountWithSlippage(expectedOutput);
 
       const tx = await ammContract.swap(ethers.ZeroAddress, 0, minAmountOut, {
-        value: ethers.parseEther(ethAmount),
+        value: ethAmount,
       });
       await tx.wait();
     });
   };
 
   const swapTokensForETH = async () => {
-    if (!tokenAmount) return;
+    if (tokenAmount === 0n) return;
 
     await executeSwapTransaction(async () => {
-      await approveTokenSpending(tokenAmount);
+      await approveTokenSpending(ethers.formatUnits(tokenAmount, 18));
       const tokenAddress = await tokenContract.getAddress();
 
       // Get expected output from contract and apply slippage protection
       const expectedOutput = await ammContract.getSwapOutput(
         tokenAddress,
-        ethers.parseEther(tokenAmount)
+        tokenAmount
       );
       const minAmountOut = calculateMinAmountWithSlippage(expectedOutput);
 
       const tx = await ammContract.swap(
         tokenAddress,
-        ethers.parseEther(tokenAmount),
+        tokenAmount,
         minAmountOut
       );
       await tx.wait();
@@ -132,8 +132,13 @@ export const Swap = ({
       {swapDirection === 'token-to-eth' ? (
         <SwapInput
           key="token-to-eth"
-          value={tokenAmount}
-          onChange={setTokenAmount}
+          value={tokenAmount === 0n ? '' : ethers.formatUnits(tokenAmount, 18)}
+          onChange={(value) => {
+            const numValue = parseFloat(value || '0');
+            setTokenAmount(
+              isNaN(numValue) ? 0n : ethers.parseUnits(numValue.toString(), 18)
+            );
+          }}
           placeholder="SIMP → ETH"
           onClick={swapTokensForETH}
           buttonText="Swap SIMP for ETH"
@@ -148,8 +153,13 @@ export const Swap = ({
       ) : (
         <SwapInput
           key="eth-to-token"
-          value={ethAmount}
-          onChange={setEthAmount}
+          value={ethAmount === 0n ? '' : ethers.formatUnits(ethAmount, 18)}
+          onChange={(value) => {
+            const numValue = parseFloat(value || '0');
+            setEthAmount(
+              isNaN(numValue) ? 0n : ethers.parseUnits(numValue.toString(), 18)
+            );
+          }}
           placeholder="ETH → SIMP"
           onClick={swapETHForTokens}
           buttonText="Swap ETH for SIMP"

--- a/apps/frontend/src/components/Swap/SwapInput.spec.tsx
+++ b/apps/frontend/src/components/Swap/SwapInput.spec.tsx
@@ -5,9 +5,7 @@ import { SwapInput } from './SwapInput';
 const mockOnClick = vi.fn();
 const mockOnChange = vi.fn();
 const mockGenerateExpectedOutput = vi.fn((value: string) =>
-  value
-    ? `≈ ${(parseFloat(value) * 2).toFixed(6)} ETH`
-    : '1 SIMP ≈ 2.000000 ETH'
+  value ? `≈ ${(parseFloat(value) * 2).toFixed(4)} ETH` : '1 SIMP ≈ 2.0000 ETH'
 );
 
 const defaultProps = {
@@ -44,13 +42,13 @@ describe('SwapInput Component', () => {
     it('should show expected output when no value', () => {
       render(<SwapInput {...defaultProps} />);
 
-      expect(screen.getByText('1 SIMP ≈ 2.000000 ETH')).toBeInTheDocument();
+      expect(screen.getByText('1 SIMP ≈ 2.0000 ETH')).toBeInTheDocument();
     });
 
     it('should show calculated output when value is provided', () => {
       render(<SwapInput {...defaultProps} amountWei={BigInt(5e18)} />);
 
-      expect(screen.getByText('≈ 10.000000 ETH')).toBeInTheDocument();
+      expect(screen.getByText('≈ 10.0000 ETH')).toBeInTheDocument();
     });
   });
 
@@ -191,11 +189,11 @@ describe('SwapInput Component', () => {
         <SwapInput {...defaultProps} amountWei={BigInt(1e18)} />
       );
 
-      expect(screen.getByText('≈ 2.000000 ETH')).toBeInTheDocument();
+      expect(screen.getByText('≈ 2.0000 ETH')).toBeInTheDocument();
 
       rerender(<SwapInput {...defaultProps} amountWei={BigInt(5e18)} />);
 
-      expect(screen.getByText('≈ 10.000000 ETH')).toBeInTheDocument();
+      expect(screen.getByText('≈ 10.0000 ETH')).toBeInTheDocument();
     });
   });
 

--- a/apps/frontend/src/components/Swap/SwapInput.spec.tsx
+++ b/apps/frontend/src/components/Swap/SwapInput.spec.tsx
@@ -11,7 +11,7 @@ const mockGenerateExpectedOutput = vi.fn((value: string) =>
 );
 
 const defaultProps = {
-  value: '',
+  amountWei: 0n,
   onChange: mockOnChange,
   placeholder: 'SIMP → ETH',
   onClick: mockOnClick,
@@ -48,7 +48,7 @@ describe('SwapInput Component', () => {
     });
 
     it('should show calculated output when value is provided', () => {
-      render(<SwapInput {...defaultProps} value="5" />);
+      render(<SwapInput {...defaultProps} amountWei={BigInt(5e18)} />);
 
       expect(screen.getByText('≈ 10.000000 ETH')).toBeInTheDocument();
     });
@@ -61,11 +61,11 @@ describe('SwapInput Component', () => {
       const input = screen.getByPlaceholderText('SIMP → ETH');
       fireEvent.change(input, { target: { value: '2.5' } });
 
-      expect(mockOnChange).toHaveBeenCalledWith('2.5');
+      expect(mockOnChange).toHaveBeenCalledWith(BigInt(2.5e18));
     });
 
     it('should display the provided value', () => {
-      render(<SwapInput {...defaultProps} value="1.5" />);
+      render(<SwapInput {...defaultProps} amountWei={BigInt(1.5e18)} />);
 
       const input = screen.getByPlaceholderText('SIMP → ETH');
       expect(input).toHaveValue(1.5);
@@ -74,7 +74,7 @@ describe('SwapInput Component', () => {
 
   describe('Button Interaction', () => {
     it('should call onClick when button is clicked', () => {
-      render(<SwapInput {...defaultProps} value="1" />);
+      render(<SwapInput {...defaultProps} amountWei={BigInt(1e18)} />);
 
       const button = screen.getByRole('button', { name: 'Swap SIMP for ETH' });
       fireEvent.click(button);
@@ -83,14 +83,14 @@ describe('SwapInput Component', () => {
     });
 
     it('should be disabled when no value is provided', () => {
-      render(<SwapInput {...defaultProps} value="" />);
+      render(<SwapInput {...defaultProps} amountWei={0n} />);
 
       const button = screen.getByRole('button', { name: 'Swap SIMP for ETH' });
       expect(button).toBeDisabled();
     });
 
     it('should be enabled when value is provided', () => {
-      render(<SwapInput {...defaultProps} value="1" />);
+      render(<SwapInput {...defaultProps} amountWei={BigInt(1e18)} />);
 
       const button = screen.getByRole('button', { name: 'Swap SIMP for ETH' });
       expect(button).toBeEnabled();
@@ -99,7 +99,13 @@ describe('SwapInput Component', () => {
 
   describe('Loading State', () => {
     it('should show loading text when isLoading is true', () => {
-      render(<SwapInput {...defaultProps} value="1" isLoading={true} />);
+      render(
+        <SwapInput
+          {...defaultProps}
+          amountWei={BigInt(1e18)}
+          isLoading={true}
+        />
+      );
 
       expect(
         screen.getByRole('button', { name: 'Waiting...' })
@@ -107,14 +113,26 @@ describe('SwapInput Component', () => {
     });
 
     it('should disable button when isLoading is true', () => {
-      render(<SwapInput {...defaultProps} value="1" isLoading={true} />);
+      render(
+        <SwapInput
+          {...defaultProps}
+          amountWei={BigInt(1e18)}
+          isLoading={true}
+        />
+      );
 
       const button = screen.getByRole('button', { name: 'Waiting...' });
       expect(button).toBeDisabled();
     });
 
     it('should not call onClick when button is clicked during loading', () => {
-      render(<SwapInput {...defaultProps} value="1" isLoading={true} />);
+      render(
+        <SwapInput
+          {...defaultProps}
+          amountWei={BigInt(1e18)}
+          isLoading={true}
+        />
+      );
 
       const button = screen.getByRole('button', { name: 'Waiting...' });
       fireEvent.click(button);
@@ -132,7 +150,9 @@ describe('SwapInput Component', () => {
     });
 
     it('should disable button when disabled prop is true', () => {
-      render(<SwapInput {...defaultProps} value="1" disabled={true} />);
+      render(
+        <SwapInput {...defaultProps} amountWei={BigInt(1e18)} disabled={true} />
+      );
 
       const button = screen.getByRole('button', { name: 'Swap SIMP for ETH' });
       expect(button).toBeDisabled();
@@ -148,7 +168,9 @@ describe('SwapInput Component', () => {
     });
 
     it('should not call onClick when button is disabled', () => {
-      render(<SwapInput {...defaultProps} value="1" disabled={true} />);
+      render(
+        <SwapInput {...defaultProps} amountWei={BigInt(1e18)} disabled={true} />
+      );
 
       const button = screen.getByRole('button', { name: 'Swap SIMP for ETH' });
       fireEvent.click(button);
@@ -159,17 +181,19 @@ describe('SwapInput Component', () => {
 
   describe('Expected Output Generation', () => {
     it('should call generateExpectedOutput with current value', () => {
-      render(<SwapInput {...defaultProps} value="3" />);
+      render(<SwapInput {...defaultProps} amountWei={BigInt(3e18)} />);
 
-      expect(mockGenerateExpectedOutput).toHaveBeenCalledWith('3');
+      expect(mockGenerateExpectedOutput).toHaveBeenCalledWith('3.0');
     });
 
     it('should update expected output when value changes', () => {
-      const { rerender } = render(<SwapInput {...defaultProps} value="1" />);
+      const { rerender } = render(
+        <SwapInput {...defaultProps} amountWei={BigInt(1e18)} />
+      );
 
       expect(screen.getByText('≈ 2.000000 ETH')).toBeInTheDocument();
 
-      rerender(<SwapInput {...defaultProps} value="5" />);
+      rerender(<SwapInput {...defaultProps} amountWei={BigInt(5e18)} />);
 
       expect(screen.getByText('≈ 10.000000 ETH')).toBeInTheDocument();
     });

--- a/apps/frontend/src/components/Swap/SwapInput.tsx
+++ b/apps/frontend/src/components/Swap/SwapInput.tsx
@@ -1,9 +1,10 @@
+import { ethers } from 'ethers';
 import { InputWithOutput } from '../shared/InputWithOutput';
 import styles from './Swap.module.scss';
 
 interface SwapInputProps {
-  value: string;
-  onChange: (value: string) => void;
+  amountWei: bigint;
+  onChange: (amountWei: bigint) => void;
   placeholder: string;
   onClick: () => void;
   buttonText: string;
@@ -13,7 +14,7 @@ interface SwapInputProps {
 }
 
 export const SwapInput = ({
-  value,
+  amountWei,
   onChange,
   placeholder,
   onClick,
@@ -24,15 +25,20 @@ export const SwapInput = ({
 }: SwapInputProps) => (
   <>
     <InputWithOutput
-      value={value}
-      onChange={onChange}
+      value={amountWei === 0n ? '' : ethers.formatUnits(amountWei, 18)}
+      onChange={(value) => {
+        const numValue = parseFloat(value || '0');
+        onChange(
+          isNaN(numValue) ? 0n : ethers.parseUnits(numValue.toString(), 18)
+        );
+      }}
       placeholder={placeholder}
       generateExpectedOutput={generateExpectedOutput}
       disabled={disabled}
     />
     <button
       onClick={onClick}
-      disabled={disabled || isLoading || !value}
+      disabled={disabled || isLoading || amountWei === 0n}
       className={styles.swapButton}
     >
       {isLoading ? 'Waiting...' : buttonText}

--- a/apps/frontend/src/components/Swap/SwapInput.tsx
+++ b/apps/frontend/src/components/Swap/SwapInput.tsx
@@ -1,4 +1,3 @@
-import { ethers } from 'ethers';
 import { InputWithOutput } from '../shared/InputWithOutput';
 import styles from './Swap.module.scss';
 
@@ -25,13 +24,8 @@ export const SwapInput = ({
 }: SwapInputProps) => (
   <>
     <InputWithOutput
-      value={amountWei === 0n ? '' : ethers.formatUnits(amountWei, 18)}
-      onChange={(value) => {
-        const numValue = parseFloat(value || '0');
-        onChange(
-          isNaN(numValue) ? 0n : ethers.parseUnits(numValue.toString(), 18)
-        );
-      }}
+      amountWei={amountWei}
+      onChange={onChange}
       placeholder={placeholder}
       generateExpectedOutput={generateExpectedOutput}
       disabled={disabled}

--- a/apps/frontend/src/components/shared/InputWithOutput.spec.tsx
+++ b/apps/frontend/src/components/shared/InputWithOutput.spec.tsx
@@ -15,7 +15,7 @@ describe('InputWithOutput', () => {
 
     const { getByPlaceholderText, getByText } = render(
       <InputWithOutput
-        value="10"
+        amountWei={BigInt(10e18)}
         onChange={mockOnChange}
         placeholder="Enter amount"
         generateExpectedOutput={mockGenerateExpectedOutput}
@@ -24,7 +24,7 @@ describe('InputWithOutput', () => {
 
     expect(getByPlaceholderText('Enter amount')).toBeTruthy();
     expect(getByText('≈ 5 ETH')).toBeTruthy();
-    expect(mockGenerateExpectedOutput).toHaveBeenCalledWith('10');
+    expect(mockGenerateExpectedOutput).toHaveBeenCalledWith('10.0');
   });
 
   it('should call onChange when input value changes', () => {
@@ -32,7 +32,7 @@ describe('InputWithOutput', () => {
 
     const { getByPlaceholderText } = render(
       <InputWithOutput
-        value=""
+        amountWei={0n}
         onChange={mockOnChange}
         placeholder="Enter amount"
         generateExpectedOutput={mockGenerateExpectedOutput}
@@ -44,7 +44,7 @@ describe('InputWithOutput', () => {
       fireEvent.change(input, { target: { value: '25' } });
     });
 
-    expect(mockOnChange).toHaveBeenCalledWith('25');
+    expect(mockOnChange).toHaveBeenCalledWith(BigInt(25e18));
   });
 
   it('should display value in input', () => {
@@ -52,7 +52,7 @@ describe('InputWithOutput', () => {
 
     const { getByPlaceholderText } = render(
       <InputWithOutput
-        value="42"
+        amountWei={BigInt(42e18)}
         onChange={mockOnChange}
         placeholder="Enter amount"
         generateExpectedOutput={mockGenerateExpectedOutput}
@@ -60,7 +60,7 @@ describe('InputWithOutput', () => {
     );
 
     const input = getByPlaceholderText('Enter amount') as HTMLInputElement;
-    expect(input.value).toBe('42');
+    expect(input.value).toBe('42.0');
   });
 
   it('should be disabled when disabled prop is true', () => {
@@ -68,7 +68,7 @@ describe('InputWithOutput', () => {
 
     const { getByPlaceholderText } = render(
       <InputWithOutput
-        value=""
+        amountWei={0n}
         onChange={mockOnChange}
         placeholder="Enter amount"
         generateExpectedOutput={mockGenerateExpectedOutput}
@@ -85,7 +85,7 @@ describe('InputWithOutput', () => {
 
     const { getByPlaceholderText } = render(
       <InputWithOutput
-        value=""
+        amountWei={0n}
         onChange={mockOnChange}
         placeholder="Enter amount"
         generateExpectedOutput={mockGenerateExpectedOutput}
@@ -106,7 +106,7 @@ describe('InputWithOutput', () => {
 
     const { getByPlaceholderText } = render(
       <InputWithOutput
-        value="3.14"
+        amountWei={BigInt(3.14e18)}
         onChange={mockOnChange}
         placeholder="Enter amount"
         generateExpectedOutput={mockGenerateExpectedOutput}
@@ -123,7 +123,7 @@ describe('InputWithOutput', () => {
 
     const { getByPlaceholderText, container } = render(
       <InputWithOutput
-        value=""
+        amountWei={0n}
         onChange={mockOnChange}
         placeholder="Enter amount"
         generateExpectedOutput={mockGenerateExpectedOutput}
@@ -141,7 +141,7 @@ describe('InputWithOutput', () => {
 
     const { container, getByPlaceholderText } = render(
       <InputWithOutput
-        value=""
+        amountWei={0n}
         onChange={mockOnChange}
         placeholder="Enter amount"
         generateExpectedOutput={mockGenerateExpectedOutput}
@@ -166,13 +166,13 @@ describe('InputWithOutput', () => {
 
     render(
       <InputWithOutput
-        value="123"
+        amountWei={BigInt(123e18)}
         onChange={mockOnChange}
         placeholder="Enter amount"
         generateExpectedOutput={mockGenerateExpectedOutput}
       />
     );
 
-    expect(mockGenerateExpectedOutput).toHaveBeenCalledWith('123');
+    expect(mockGenerateExpectedOutput).toHaveBeenCalledWith('123.0');
   });
 });

--- a/apps/frontend/src/components/shared/InputWithOutput.tsx
+++ b/apps/frontend/src/components/shared/InputWithOutput.tsx
@@ -32,12 +32,8 @@ export const InputWithOutput = ({
             onChange(0n);
             return;
           }
-          const numValue = parseFloat(value);
-          if (isNaN(numValue)) {
-            return;
-          }
           try {
-            const weiValue = ethers.parseUnits(numValue.toString(), 18);
+            const weiValue = ethers.parseUnits(value, 18);
             onChange(weiValue);
           } catch {
             // Invalid input, ignore

--- a/apps/frontend/src/components/shared/InputWithOutput.tsx
+++ b/apps/frontend/src/components/shared/InputWithOutput.tsx
@@ -1,30 +1,55 @@
+import { ethers } from 'ethers';
 import styles from './InputWithOutput.module.scss';
 
 interface InputWithOutputProps {
-  value: string;
-  onChange: (value: string) => void;
+  amountWei: bigint;
+  onChange: (amountWei: bigint) => void;
   placeholder: string;
   generateExpectedOutput: (value: string) => string;
   disabled?: boolean;
 }
 
 export const InputWithOutput = ({
-  value,
+  amountWei,
   onChange,
   placeholder,
   generateExpectedOutput,
   disabled = false,
-}: InputWithOutputProps) => (
-  <div className={styles.inputRow}>
-    <input
-      type="number"
-      step="0.01"
-      value={value}
-      onChange={(e) => !disabled && onChange(e.target.value)}
-      placeholder={placeholder}
-      className={styles.inputLeft}
-      disabled={disabled}
-    />
-    <div className={styles.expectedOutput}>{generateExpectedOutput(value)}</div>
-  </div>
-);
+}: InputWithOutputProps) => {
+  const displayValue =
+    amountWei === 0n ? '' : ethers.formatUnits(amountWei, 18);
+
+  return (
+    <div className={styles.inputRow}>
+      <input
+        type="number"
+        step="0.01"
+        value={displayValue}
+        onChange={(e) => {
+          if (disabled) return;
+          const value = e.target.value;
+          if (value === '') {
+            onChange(0n);
+            return;
+          }
+          const numValue = parseFloat(value);
+          if (isNaN(numValue)) {
+            return;
+          }
+          try {
+            const weiValue = ethers.parseUnits(numValue.toString(), 18);
+            onChange(weiValue);
+          } catch {
+            // Invalid input, ignore
+          }
+        }}
+        placeholder={placeholder}
+        className={styles.inputLeft}
+        disabled={disabled}
+      />
+      <div className={styles.expectedOutput}>
+        {generateExpectedOutput(displayValue)}
+      </div>
+    </div>
+  );
+};

--- a/apps/frontend/src/test-mocks.ts
+++ b/apps/frontend/src/test-mocks.ts
@@ -80,8 +80,8 @@ export const createDefaultProps = (
   return {
     tokenContract,
     ammContract,
-    poolEthReserve: '10.0',
-    poolTokenReserve: '20.0',
+    poolEthReserve: BigInt(10 * 1e18), // 10 ETH in wei
+    poolTokenReserve: BigInt(20 * 1e18), // 20 tokens in wei
     ...overrides,
   };
 };

--- a/apps/frontend/src/test-mocks.ts
+++ b/apps/frontend/src/test-mocks.ts
@@ -80,8 +80,8 @@ export const createDefaultProps = (
   return {
     tokenContract,
     ammContract,
-    poolEthReserve: BigInt(10 * 1e18), // 10 ETH in wei
-    poolTokenReserve: BigInt(20 * 1e18), // 20 tokens in wei
+    poolEthReserve: BigInt(10e18), // 10 ETH in wei
+    poolTokenReserve: BigInt(20e18), // 20 tokens in wei
     ...overrides,
   };
 };

--- a/apps/frontend/src/utils/ammCalculations.spec.ts
+++ b/apps/frontend/src/utils/ammCalculations.spec.ts
@@ -325,14 +325,19 @@ describe('ammCalculations', () => {
         );
 
       // Should get close to original amounts (some precision loss expected)
-      expect(parseFloat(formatUnits(ethReturned, 18))).toBeCloseTo(
-        parseFloat(formatUnits(ethAmount, 18)),
-        10
-      );
-      expect(parseFloat(formatUnits(tokenReturned, 18))).toBeCloseTo(
-        parseFloat(formatUnits(tokenAmount, 18)),
-        10
-      );
+      // Allow for small precision differences in BigInt calculations
+      const ethDiff =
+        ethReturned > ethAmount
+          ? ethReturned - ethAmount
+          : ethAmount - ethReturned;
+      const tokenDiff =
+        tokenReturned > tokenAmount
+          ? tokenReturned - tokenAmount
+          : tokenAmount - tokenReturned;
+
+      // Tolerance of 1000 wei (very small amount)
+      expect(ethDiff).toBeLessThanOrEqual(1000n);
+      expect(tokenDiff).toBeLessThanOrEqual(1000n);
     });
 
     it('should handle large swap impact on reserves', () => {

--- a/apps/frontend/src/utils/ammCalculations.spec.ts
+++ b/apps/frontend/src/utils/ammCalculations.spec.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect } from 'vitest';
+import { parseUnits, formatUnits } from 'ethers';
+import {
+  calculateSwapOutput,
+  calculateRequiredTokenAmount,
+  calculateRequiredEthAmount,
+  calculateRemoveLiquidityOutput,
+  calculateAddLiquidityOutput,
+  calculateExchangeRate,
+  AMM_FEE_PERCENT,
+  AMM_FEE_BASIS_POINTS,
+} from './ammCalculations';
+
+describe('ammCalculations', () => {
+  describe('Constants', () => {
+    it('should have correct fee constants', () => {
+      expect(AMM_FEE_PERCENT).toBe(0.3);
+      expect(AMM_FEE_BASIS_POINTS).toBe(997);
+    });
+  });
+
+  describe('Wei conversion utilities', () => {
+    it('should convert wei to ETH correctly', () => {
+      expect(formatUnits(1000000000000000000n, 18)).toBe('1.0'); // 1 ETH
+      expect(formatUnits(500000000000000000n, 18)).toBe('0.5'); // 0.5 ETH
+      expect(formatUnits(0n, 18)).toBe('0.0');
+    });
+
+    it('should convert ETH to wei correctly', () => {
+      expect(parseUnits('1', 18)).toBe(1000000000000000000n); // 1 ETH
+      expect(parseUnits('0.5', 18)).toBe(500000000000000000n); // 0.5 ETH
+      expect(parseUnits('0', 18)).toBe(0n);
+    });
+  });
+
+  describe('calculateSwapOutput', () => {
+    it('should calculate swap output with 0.3% fee', () => {
+      const amountIn = parseUnits('1', 18); // 1 ETH
+      const reserveIn = parseUnits('10', 18); // 10 ETH
+      const reserveOut = parseUnits('20', 18); // 20 tokens
+
+      const result = calculateSwapOutput(amountIn, reserveIn, reserveOut);
+      const resultEth = parseFloat(formatUnits(result, 18));
+
+      // Expected: (20 * (1 * 997 / 1000)) / (10 + (1 * 997 / 1000))
+      // = (20 * 0.997) / (10 + 0.997) = 19.94 / 10.997 ≈ 1.8132
+      expect(resultEth).toBeCloseTo(1.8132, 3);
+    });
+
+    it('should return 0 for invalid inputs', () => {
+      expect(
+        calculateSwapOutput(0n, parseUnits('10', 18), parseUnits('20', 18))
+      ).toBe(0n);
+      expect(
+        calculateSwapOutput(parseUnits('1', 18), 0n, parseUnits('20', 18))
+      ).toBe(0n);
+      expect(
+        calculateSwapOutput(parseUnits('1', 18), parseUnits('10', 18), 0n)
+      ).toBe(0n);
+    });
+
+    it('should handle large numbers correctly', () => {
+      const amountIn = parseUnits('1000', 18);
+      const reserveIn = parseUnits('10000', 18);
+      const reserveOut = parseUnits('20000', 18);
+
+      const result = calculateSwapOutput(amountIn, reserveIn, reserveOut);
+      expect(result).toBeGreaterThan(0n);
+    });
+  });
+
+  describe('calculateRequiredTokenAmount', () => {
+    it('should calculate proportional token amount', () => {
+      const ethAmount = parseUnits('5', 18);
+      const poolEthReserve = parseUnits('10', 18);
+      const poolTokenReserve = parseUnits('20', 18);
+
+      const result = calculateRequiredTokenAmount(
+        ethAmount,
+        poolEthReserve,
+        poolTokenReserve
+      );
+      const resultEth = parseFloat(formatUnits(result, 18));
+
+      // 5 ETH * (20 tokens / 10 ETH) = 10 tokens
+      expect(resultEth).toBe(10);
+    });
+
+    it('should return 0 for invalid inputs', () => {
+      expect(
+        calculateRequiredTokenAmount(
+          0n,
+          parseUnits('10', 18),
+          parseUnits('20', 18)
+        )
+      ).toBe(0n);
+      expect(
+        calculateRequiredTokenAmount(
+          parseUnits('5', 18),
+          0n,
+          parseUnits('20', 18)
+        )
+      ).toBe(0n);
+      expect(
+        calculateRequiredTokenAmount(
+          parseUnits('5', 18),
+          parseUnits('10', 18),
+          0n
+        )
+      ).toBe(0n);
+    });
+
+    it('should handle fractional amounts', () => {
+      const ethAmount = parseUnits('2.5', 18);
+      const poolEthReserve = parseUnits('10', 18);
+      const poolTokenReserve = parseUnits('30', 18);
+
+      const result = calculateRequiredTokenAmount(
+        ethAmount,
+        poolEthReserve,
+        poolTokenReserve
+      );
+      const resultEth = parseFloat(formatUnits(result, 18));
+
+      // 2.5 ETH * (30 tokens / 10 ETH) = 7.5 tokens
+      expect(resultEth).toBeCloseTo(7.5, 10);
+    });
+  });
+
+  describe('calculateRequiredEthAmount', () => {
+    it('should calculate proportional ETH amount', () => {
+      const tokenAmount = parseUnits('10', 18);
+      const poolEthReserve = parseUnits('10', 18);
+      const poolTokenReserve = parseUnits('20', 18);
+
+      const result = calculateRequiredEthAmount(
+        tokenAmount,
+        poolEthReserve,
+        poolTokenReserve
+      );
+      const resultEth = parseFloat(formatUnits(result, 18));
+
+      // 10 tokens * (10 ETH / 20 tokens) = 5 ETH
+      expect(resultEth).toBe(5);
+    });
+
+    it('should return 0 for invalid inputs', () => {
+      expect(
+        calculateRequiredEthAmount(
+          0n,
+          parseUnits('10', 18),
+          parseUnits('20', 18)
+        )
+      ).toBe(0n);
+      expect(
+        calculateRequiredEthAmount(
+          parseUnits('10', 18),
+          0n,
+          parseUnits('20', 18)
+        )
+      ).toBe(0n);
+      expect(
+        calculateRequiredEthAmount(
+          parseUnits('10', 18),
+          parseUnits('10', 18),
+          0n
+        )
+      ).toBe(0n);
+    });
+  });
+
+  describe('calculateRemoveLiquidityOutput', () => {
+    it('should calculate proportional removal amounts', () => {
+      const lpTokenAmount = parseUnits('5', 18);
+      const poolEthReserve = parseUnits('10', 18);
+      const poolTokenReserve = parseUnits('20', 18);
+      const totalLPTokens = parseUnits('10', 18);
+
+      const result = calculateRemoveLiquidityOutput(
+        lpTokenAmount,
+        poolEthReserve,
+        poolTokenReserve,
+        totalLPTokens
+      );
+
+      const ethAmount = parseFloat(formatUnits(result.ethAmount, 18));
+      const tokenAmount = parseFloat(formatUnits(result.tokenAmount, 18));
+
+      // 5 LP tokens out of 10 total = 50% of pool
+      // 50% of 10 ETH = 5 ETH, 50% of 20 tokens = 10 tokens
+      expect(ethAmount).toBe(5);
+      expect(tokenAmount).toBe(10);
+    });
+
+    it('should return zero amounts for invalid inputs', () => {
+      const result = calculateRemoveLiquidityOutput(
+        0n,
+        parseUnits('10', 18),
+        parseUnits('20', 18),
+        parseUnits('10', 18)
+      );
+      expect(result.ethAmount).toBe(0n);
+      expect(result.tokenAmount).toBe(0n);
+    });
+
+    it('should handle fractional LP tokens', () => {
+      const lpTokenAmount = parseUnits('2.5', 18);
+      const poolEthReserve = parseUnits('10', 18);
+      const poolTokenReserve = parseUnits('30', 18);
+      const totalLPTokens = parseUnits('10', 18);
+
+      const result = calculateRemoveLiquidityOutput(
+        lpTokenAmount,
+        poolEthReserve,
+        poolTokenReserve,
+        totalLPTokens
+      );
+
+      const ethAmount = parseFloat(formatUnits(result.ethAmount, 18));
+      const tokenAmount = parseFloat(formatUnits(result.tokenAmount, 18));
+
+      // 2.5 LP tokens out of 10 total = 25% of pool
+      expect(ethAmount).toBeCloseTo(2.5, 10);
+      expect(tokenAmount).toBeCloseTo(7.5, 10);
+    });
+  });
+
+  describe('calculateAddLiquidityOutput', () => {
+    it('should calculate initial LP tokens using sqrt for empty pool', () => {
+      const tokenAmount = parseUnits('4', 18);
+      const ethAmount = parseUnits('9', 18);
+      const poolEthReserve = 0n;
+      const poolTokenReserve = 0n;
+      const totalLPTokens = 0n;
+
+      const result = calculateAddLiquidityOutput(
+        tokenAmount,
+        ethAmount,
+        poolEthReserve,
+        poolTokenReserve,
+        totalLPTokens
+      );
+
+      const resultEth = parseFloat(formatUnits(result, 18));
+
+      // sqrt(4 * 9 * 1e36) = sqrt(36 * 1e36) = 6 * 1e18 = 6 ETH worth of LP tokens
+      expect(resultEth).toBeCloseTo(6, 10);
+    });
+
+    it('should calculate LP tokens using minimum ratio for existing pool', () => {
+      const tokenAmount = parseUnits('10', 18);
+      const ethAmount = parseUnits('5', 18);
+      const poolEthReserve = parseUnits('10', 18);
+      const poolTokenReserve = parseUnits('20', 18);
+      const totalLPTokens = parseUnits('10', 18);
+
+      const result = calculateAddLiquidityOutput(
+        tokenAmount,
+        ethAmount,
+        poolEthReserve,
+        poolTokenReserve,
+        totalLPTokens
+      );
+
+      const resultEth = parseFloat(formatUnits(result, 18));
+
+      // Token ratio: 10 tokens / 20 pool tokens * 10 total LP = 5 LP tokens
+      // ETH ratio: 5 ETH / 10 pool ETH * 10 total LP = 5 LP tokens
+      // Min of (5, 5) = 5 LP tokens
+      expect(resultEth).toBe(5);
+    });
+  });
+
+  describe('calculateExchangeRate', () => {
+    it('should calculate simple exchange rate', () => {
+      const reserveIn = parseUnits('10', 18);
+      const reserveOut = parseUnits('20', 18);
+
+      const result = calculateExchangeRate(reserveIn, reserveOut);
+
+      // 20 out / 10 in = 2:1 ratio
+      expect(result).toBe(2);
+    });
+
+    it('should return 0 for invalid inputs', () => {
+      expect(calculateExchangeRate(0n, parseUnits('20', 18))).toBe(0);
+      expect(calculateExchangeRate(parseUnits('10', 18), 0n)).toBe(0);
+    });
+
+    it('should handle fractional rates', () => {
+      const reserveIn = parseUnits('20', 18);
+      const reserveOut = parseUnits('10', 18);
+
+      const result = calculateExchangeRate(reserveIn, reserveOut);
+
+      // 10 out / 20 in = 0.5:1 ratio
+      expect(result).toBe(0.5);
+    });
+  });
+
+  describe('Integration scenarios', () => {
+    it('should maintain consistency between add/remove liquidity', () => {
+      const tokenAmount = parseUnits('20', 18);
+      const ethAmount = parseUnits('10', 18);
+      const poolEthReserve = parseUnits('100', 18);
+      const poolTokenReserve = parseUnits('200', 18);
+      const totalLPTokens = parseUnits('100', 18);
+
+      // Add liquidity
+      const lpTokensReceived = calculateAddLiquidityOutput(
+        tokenAmount,
+        ethAmount,
+        poolEthReserve,
+        poolTokenReserve,
+        totalLPTokens
+      );
+
+      // Remove the same LP tokens
+      const { ethAmount: ethReturned, tokenAmount: tokenReturned } =
+        calculateRemoveLiquidityOutput(
+          lpTokensReceived,
+          poolEthReserve + ethAmount,
+          poolTokenReserve + tokenAmount,
+          totalLPTokens + lpTokensReceived
+        );
+
+      // Should get close to original amounts (some precision loss expected)
+      expect(parseFloat(formatUnits(ethReturned, 18))).toBeCloseTo(
+        parseFloat(formatUnits(ethAmount, 18)),
+        10
+      );
+      expect(parseFloat(formatUnits(tokenReturned, 18))).toBeCloseTo(
+        parseFloat(formatUnits(tokenAmount, 18)),
+        10
+      );
+    });
+
+    it('should handle large swap impact on reserves', () => {
+      const amountIn = parseUnits('50', 18); // Large swap
+      const reserveIn = parseUnits('100', 18);
+      const reserveOut = parseUnits('200', 18);
+
+      const result = calculateSwapOutput(amountIn, reserveIn, reserveOut);
+
+      // Should be less than reserveOut due to slippage
+      expect(result).toBeLessThan(reserveOut);
+      expect(result).toBeGreaterThan(0n);
+    });
+  });
+});

--- a/apps/frontend/src/utils/ammCalculations.spec.ts
+++ b/apps/frontend/src/utils/ammCalculations.spec.ts
@@ -21,14 +21,14 @@ describe('ammCalculations', () => {
 
   describe('Wei conversion utilities', () => {
     it('should convert wei to ETH correctly', () => {
-      expect(formatUnits(1000000000000000000n, 18)).toBe('1.0'); // 1 ETH
-      expect(formatUnits(500000000000000000n, 18)).toBe('0.5'); // 0.5 ETH
+      expect(formatUnits(BigInt(1e18), 18)).toBe('1.0'); // 1 ETH
+      expect(formatUnits(BigInt(0.5e18), 18)).toBe('0.5'); // 0.5 ETH
       expect(formatUnits(0n, 18)).toBe('0.0');
     });
 
     it('should convert ETH to wei correctly', () => {
-      expect(parseUnits('1', 18)).toBe(1000000000000000000n); // 1 ETH
-      expect(parseUnits('0.5', 18)).toBe(500000000000000000n); // 0.5 ETH
+      expect(parseUnits('1', 18)).toBe(BigInt(1e18)); // 1 ETH
+      expect(parseUnits('0.5', 18)).toBe(BigInt(0.5e18)); // 0.5 ETH
       expect(parseUnits('0', 18)).toBe(0n);
     });
   });

--- a/apps/frontend/src/utils/ammCalculations.ts
+++ b/apps/frontend/src/utils/ammCalculations.ts
@@ -1,0 +1,155 @@
+/**
+ * Utility functions for AMM (Automated Market Maker) calculations
+ * All calculations use wei (BigInt) as base unit for precision
+ * Components should format values for display
+ */
+
+/**
+ * AMM fee percentage (0.3%)
+ */
+export const AMM_FEE_PERCENT = 0.3;
+export const AMM_FEE_BASIS_POINTS = 997; // 100% - 0.3% = 99.7% = 997/1000
+
+/**
+ * Calculates swap output using constant product formula with fee
+ * Formula: amountOut = (reserveOut * amountInWithFee) / (reserveIn + amountInWithFee)
+ * where amountInWithFee = amountIn * 997 / 1000 (0.3% fee)
+ *
+ * @param amountIn Input amount in wei
+ * @param reserveIn Reserve of input token in wei
+ * @param reserveOut Reserve of output token in wei
+ * @returns Output amount in wei
+ */
+export function calculateSwapOutput(
+  amountIn: bigint,
+  reserveIn: bigint,
+  reserveOut: bigint
+): bigint {
+  if (amountIn <= 0n || reserveIn <= 0n || reserveOut <= 0n) {
+    return 0n;
+  }
+
+  // Apply 0.3% fee exactly as contract does
+  const amountInWithFee = (amountIn * BigInt(AMM_FEE_BASIS_POINTS)) / 1000n;
+
+  // Constant product formula
+  return (reserveOut * amountInWithFee) / (reserveIn + amountInWithFee);
+}
+
+/**
+ * Calculates required token amount for adding liquidity to maintain pool ratio
+ *
+ * @param ethAmount ETH amount to add in wei
+ * @param poolEthReserve Current ETH reserve in pool in wei
+ * @param poolTokenReserve Current token reserve in pool in wei
+ * @returns Required token amount in wei to maintain ratio
+ */
+export function calculateRequiredTokenAmount(
+  ethAmount: bigint,
+  poolEthReserve: bigint,
+  poolTokenReserve: bigint
+): bigint {
+  if (ethAmount <= 0n || poolEthReserve <= 0n || poolTokenReserve <= 0n) {
+    return 0n;
+  }
+
+  return (ethAmount * poolTokenReserve) / poolEthReserve;
+}
+
+/**
+ * Calculates required ETH amount for adding liquidity to maintain pool ratio
+ *
+ * @param tokenAmount Token amount to add in wei
+ * @param poolEthReserve Current ETH reserve in pool in wei
+ * @param poolTokenReserve Current token reserve in pool in wei
+ * @returns Required ETH amount in wei to maintain ratio
+ */
+export function calculateRequiredEthAmount(
+  tokenAmount: bigint,
+  poolEthReserve: bigint,
+  poolTokenReserve: bigint
+): bigint {
+  if (tokenAmount <= 0n || poolEthReserve <= 0n || poolTokenReserve <= 0n) {
+    return 0n;
+  }
+
+  return (tokenAmount * poolEthReserve) / poolTokenReserve;
+}
+
+/**
+ * Calculates token amounts received when removing liquidity
+ *
+ * @param lpTokenAmount LP tokens to remove in wei
+ * @param poolEthReserve Current ETH reserve in pool in wei
+ * @param poolTokenReserve Current token reserve in pool in wei
+ * @param totalLPTokens Total LP tokens in circulation in wei
+ * @returns Object with ETH and token amounts to receive in wei
+ */
+export function calculateRemoveLiquidityOutput(
+  lpTokenAmount: bigint,
+  poolEthReserve: bigint,
+  poolTokenReserve: bigint,
+  totalLPTokens: bigint
+): { ethAmount: bigint; tokenAmount: bigint } {
+  if (lpTokenAmount <= 0n || totalLPTokens <= 0n) {
+    return { ethAmount: 0n, tokenAmount: 0n };
+  }
+
+  const ethAmount = (lpTokenAmount * poolEthReserve) / totalLPTokens;
+  const tokenAmount = (lpTokenAmount * poolTokenReserve) / totalLPTokens;
+
+  return { ethAmount, tokenAmount };
+}
+
+/**
+ * Calculates LP tokens received when adding liquidity
+ *
+ * @param tokenAmount Token amount to add in wei
+ * @param ethAmount ETH amount to add in wei
+ * @param poolEthReserve Current ETH reserve in pool in wei
+ * @param poolTokenReserve Current token reserve in pool in wei
+ * @param totalLPTokens Total LP tokens in circulation in wei
+ * @returns LP tokens to receive in wei
+ */
+export function calculateAddLiquidityOutput(
+  tokenAmount: bigint,
+  ethAmount: bigint,
+  poolEthReserve: bigint,
+  poolTokenReserve: bigint,
+  totalLPTokens: bigint
+): bigint {
+  if (totalLPTokens === 0n) {
+    // First liquidity provision - use sqrt of product
+    // Convert to Number for sqrt calculation, then back to BigInt
+    const product = tokenAmount * ethAmount;
+    const sqrtProduct = BigInt(Math.floor(Math.sqrt(Number(product))));
+    return sqrtProduct;
+  } else {
+    // Subsequent liquidity - use minimum of ratios
+    const tokenRatio = (tokenAmount * totalLPTokens) / poolTokenReserve;
+    const ethRatio = (ethAmount * totalLPTokens) / poolEthReserve;
+    return tokenRatio < ethRatio ? tokenRatio : ethRatio;
+  }
+}
+
+/**
+ * Calculates simple exchange rate between two tokens
+ *
+ * @param reserveIn Reserve of input token in wei
+ * @param reserveOut Reserve of output token in wei
+ * @returns Exchange rate as number (how much output per 1 unit of input)
+ */
+export function calculateExchangeRate(
+  reserveIn: bigint,
+  reserveOut: bigint
+): number {
+  if (reserveIn <= 0n || reserveOut <= 0n) {
+    return 0;
+  }
+
+  // Convert to numbers for rate calculation
+  const reserveInNum = Number(reserveIn);
+  const reserveOutNum = Number(reserveOut);
+
+  return reserveOutNum / reserveInNum;
+}

--- a/apps/frontend/src/utils/balances.spec.ts
+++ b/apps/frontend/src/utils/balances.spec.ts
@@ -129,8 +129,8 @@ describe('Balance Utilities', () => {
       const result = await getPoolReserves(mockSigner);
 
       expect(result).toEqual({
-        ethReserve: 10.0,
-        tokenReserve: 20.0,
+        ethReserve: BigInt(10e18),
+        tokenReserve: BigInt(20e18),
       });
 
       expect(mockAmmContract.reserveETH).toHaveBeenCalled();
@@ -144,8 +144,8 @@ describe('Balance Utilities', () => {
       const result = await getPoolReserves(mockSigner);
 
       expect(result).toEqual({
-        ethReserve: 0.0,
-        tokenReserve: 0.0,
+        ethReserve: BigInt(0),
+        tokenReserve: BigInt(0),
       });
     });
 
@@ -156,8 +156,8 @@ describe('Balance Utilities', () => {
       const result = await getPoolReserves(mockSigner);
 
       expect(result).toEqual({
-        ethReserve: 15.5,
-        tokenReserve: 31.25,
+        ethReserve: BigInt(15.5e18),
+        tokenReserve: BigInt(31.25e18),
       });
     });
 
@@ -219,7 +219,10 @@ describe('Balance Utilities', () => {
       ]);
 
       expect(walletBalances).toEqual({ ethBalance: 3.0, tokenBalance: 500.0 });
-      expect(poolBalances).toEqual({ ethReserve: 12.0, tokenReserve: 24.0 });
+      expect(poolBalances).toEqual({
+        ethReserve: BigInt(12e18),
+        tokenReserve: BigInt(24e18),
+      });
     });
 
     it('should handle large numbers correctly', async () => {

--- a/apps/frontend/src/utils/balances.ts
+++ b/apps/frontend/src/utils/balances.ts
@@ -8,8 +8,8 @@ export interface WalletBalances {
 }
 
 export interface PoolReserves {
-  ethReserve: number;
-  tokenReserve: number;
+  ethReserve: bigint;
+  tokenReserve: bigint;
 }
 
 export interface LiquidityBalances {
@@ -53,8 +53,8 @@ export const getPoolReserves = async (
   ]);
 
   return {
-    ethReserve: Number(ethers.formatEther(ethReserve)),
-    tokenReserve: Number(ethers.formatEther(tokenReserve)),
+    ethReserve,
+    tokenReserve,
   };
 };
 

--- a/apps/frontend/src/utils/expectedOutputCalculators.spec.ts
+++ b/apps/frontend/src/utils/expectedOutputCalculators.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { parseUnits } from 'ethers';
 import {
   createRemoveLiquidityOutputCalculator,
   createSwapOutputCalculator,
@@ -8,9 +9,9 @@ describe('expectedOutputCalculators', () => {
   describe('createRemoveLiquidityOutputCalculator', () => {
     it('should calculate correct output for valid inputs', () => {
       const calculator = createRemoveLiquidityOutputCalculator(
-        10.0, // poolEthReserve
-        20.0, // poolTokenReserve
-        5.0 // totalLPTokens
+        parseUnits('10.0', 18), // poolEthReserve
+        parseUnits('20.0', 18), // poolTokenReserve
+        parseUnits('5.0', 18) // totalLPTokens
       );
 
       const result = calculator('2.5');
@@ -18,7 +19,11 @@ describe('expectedOutputCalculators', () => {
     });
 
     it('should return zero output for empty input', () => {
-      const calculator = createRemoveLiquidityOutputCalculator(10.0, 20.0, 5.0);
+      const calculator = createRemoveLiquidityOutputCalculator(
+        parseUnits('10.0', 18),
+        parseUnits('20.0', 18),
+        parseUnits('5.0', 18)
+      );
 
       expect(calculator('')).toBe('0.0000 SIMP + 0.0000 ETH');
       expect(calculator('0')).toBe('0.0000 SIMP + 0.0000 ETH');
@@ -26,9 +31,9 @@ describe('expectedOutputCalculators', () => {
 
     it('should return zero output when total LP tokens is zero', () => {
       const calculator = createRemoveLiquidityOutputCalculator(
-        10.0,
-        20.0,
-        0 // totalLPTokens = 0
+        parseUnits('10.0', 18),
+        parseUnits('20.0', 18),
+        0n // totalLPTokens = 0
       );
 
       const result = calculator('2.5');
@@ -39,34 +44,34 @@ describe('expectedOutputCalculators', () => {
   describe('createSwapOutputCalculator', () => {
     it('should calculate correct output for token to ETH swap', () => {
       const calculator = createSwapOutputCalculator(
-        10.0, // poolEthReserve
-        20.0, // poolTokenReserve
+        parseUnits('10.0', 18), // poolEthReserve
+        parseUnits('20.0', 18), // poolTokenReserve
         'SIMP', // inputToken
         'ETH' // outputToken
       );
 
       const result = calculator('5');
-      // Expected: (10 * 5) / (20 + 5) = 2.000000
-      expect(result).toBe('≈ 2.000000 ETH');
+      // Expected: with 0.3% fee, should be close to 1.995 ETH
+      expect(result).toMatch(/≈ 1\.995.* ETH/);
     });
 
     it('should calculate correct output for ETH to token swap', () => {
       const calculator = createSwapOutputCalculator(
-        10.0, // poolEthReserve
-        20.0, // poolTokenReserve
+        parseUnits('10.0', 18), // poolEthReserve
+        parseUnits('20.0', 18), // poolTokenReserve
         'ETH', // inputToken
         'SIMP' // outputToken
       );
 
       const result = calculator('2');
-      // Expected: (20 * 2) / (10 + 2) = 3.333333
-      expect(result).toBe('≈ 3.333333 SIMP');
+      // Expected: with 0.3% fee, should be close to 3.325 SIMP
+      expect(result).toMatch(/≈ 3\.32.* SIMP/);
     });
 
     it('should return exchange rate for empty input in token to ETH direction', () => {
       const calculator = createSwapOutputCalculator(
-        10.0,
-        20.0,
+        parseUnits('10.0', 18),
+        parseUnits('20.0', 18),
         'SIMP', // inputToken
         'ETH' // outputToken
       );
@@ -77,8 +82,8 @@ describe('expectedOutputCalculators', () => {
 
     it('should return exchange rate for empty input in ETH to token direction', () => {
       const calculator = createSwapOutputCalculator(
-        10.0,
-        20.0,
+        parseUnits('10.0', 18),
+        parseUnits('20.0', 18),
         'ETH', // inputToken
         'SIMP' // outputToken
       );
@@ -89,8 +94,8 @@ describe('expectedOutputCalculators', () => {
 
     it('should return fallback when pool reserves are zero', () => {
       const calculator = createSwapOutputCalculator(
-        0, // poolEthReserve = 0
-        0, // poolTokenReserve = 0
+        0n, // poolEthReserve = 0
+        0n, // poolTokenReserve = 0
         'SIMP', // inputToken
         'ETH' // outputToken
       );

--- a/apps/frontend/src/utils/expectedOutputCalculators.spec.ts
+++ b/apps/frontend/src/utils/expectedOutputCalculators.spec.ts
@@ -76,8 +76,8 @@ describe('expectedOutputCalculators', () => {
         'ETH' // outputToken
       );
 
-      expect(calculator('')).toBe('1 SIMP ≈ 0.500000 ETH');
-      expect(calculator('0')).toBe('1 SIMP ≈ 0.500000 ETH');
+      expect(calculator('')).toBe('1 SIMP ≈ 0.5000 ETH');
+      expect(calculator('0')).toBe('1 SIMP ≈ 0.5000 ETH');
     });
 
     it('should return exchange rate for empty input in ETH to token direction', () => {

--- a/apps/frontend/src/utils/expectedOutputCalculators.ts
+++ b/apps/frontend/src/utils/expectedOutputCalculators.ts
@@ -1,24 +1,38 @@
 // Utility functions for calculating expected outputs in various components
+import { parseUnits, formatUnits } from 'ethers';
+import {
+  calculateRemoveLiquidityOutput,
+  calculateSwapOutput,
+  calculateExchangeRate,
+} from './ammCalculations';
 
 /**
  * Calculates expected output for removing liquidity
  */
 export const createRemoveLiquidityOutputCalculator = (
-  poolEthReserve: number,
-  poolTokenReserve: number,
-  totalLPTokens: number
+  poolEthReserve: bigint,
+  poolTokenReserve: bigint,
+  totalLPTokens: bigint
 ) => {
   return (lpAmountString: string): string => {
     const lpAmount = parseFloat(lpAmountString);
 
-    if (!lpAmount || lpAmount <= 0 || totalLPTokens === 0) {
+    if (!lpAmount || lpAmount <= 0 || totalLPTokens === 0n) {
       return '0.0000 SIMP + 0.0000 ETH';
     }
 
-    const ethAmount = (lpAmount * poolEthReserve) / totalLPTokens;
-    const tokenAmount = (lpAmount * poolTokenReserve) / totalLPTokens;
+    const lpAmountWei = parseUnits(lpAmount.toString(), 18);
+    const { ethAmount, tokenAmount } = calculateRemoveLiquidityOutput(
+      lpAmountWei,
+      poolEthReserve,
+      poolTokenReserve,
+      totalLPTokens
+    );
 
-    return `${tokenAmount.toFixed(4)} SIMP + ${ethAmount.toFixed(4)} ETH`;
+    const ethAmountFormatted = parseFloat(formatUnits(ethAmount, 18));
+    const tokenAmountFormatted = parseFloat(formatUnits(tokenAmount, 18));
+
+    return `${tokenAmountFormatted.toFixed(4)} SIMP + ${ethAmountFormatted.toFixed(4)} ETH`;
   };
 };
 
@@ -26,23 +40,23 @@ export const createRemoveLiquidityOutputCalculator = (
  * Calculates expected output for swap operations
  */
 export const createSwapOutputCalculator = (
-  poolEthReserve: number,
-  poolTokenReserve: number,
+  poolEthReserve: bigint,
+  poolTokenReserve: bigint,
   inputToken: string,
   outputToken: string
 ) => {
   const isEthToToken = inputToken === 'ETH';
 
   const getExchangeRate = (): string => {
-    if (poolEthReserve === 0 || poolTokenReserve === 0) return '';
+    if (poolEthReserve === 0n || poolTokenReserve === 0n) return '';
 
     if (isEthToToken) {
       // Show 1 ETH = x SIMP
-      const rate = poolTokenReserve / poolEthReserve;
+      const rate = calculateExchangeRate(poolEthReserve, poolTokenReserve);
       return `1 ${inputToken} ≈ ${rate.toFixed(4)} ${outputToken}`;
     } else {
       // Show 1 SIMP = x ETH
-      const rate = poolEthReserve / poolTokenReserve;
+      const rate = calculateExchangeRate(poolTokenReserve, poolEthReserve);
       return `1 ${inputToken} ≈ ${rate.toFixed(6)} ${outputToken}`;
     }
   };
@@ -54,24 +68,32 @@ export const createSwapOutputCalculator = (
       return getExchangeRate() || `≈ 0 ${outputToken}`;
     }
 
-    if (poolEthReserve === 0 || poolTokenReserve === 0) {
+    if (poolEthReserve === 0n || poolTokenReserve === 0n) {
       return getExchangeRate() || `≈ 0 ${outputToken}`;
     }
 
-    // Using constant product formula: x * y = k
-    // Output = (y * inputX) / (x + inputX)
-    let outputAmount: number;
+    // Convert input to wei for calculation
+    const inputAmountWei = parseUnits(inputAmount.toString(), 18);
+    let outputAmountWei: bigint;
 
     if (isEthToToken) {
       // ETH input -> Token output
-      outputAmount =
-        (poolTokenReserve * inputAmount) / (poolEthReserve + inputAmount);
+      outputAmountWei = calculateSwapOutput(
+        inputAmountWei,
+        poolEthReserve,
+        poolTokenReserve
+      );
     } else {
       // Token input -> ETH output
-      outputAmount =
-        (poolEthReserve * inputAmount) / (poolTokenReserve + inputAmount);
+      outputAmountWei = calculateSwapOutput(
+        inputAmountWei,
+        poolTokenReserve,
+        poolEthReserve
+      );
     }
 
+    // Convert back to display format
+    const outputAmount = parseFloat(formatUnits(outputAmountWei, 18));
     return `≈ ${outputAmount.toFixed(6)} ${outputToken}`;
   };
 };

--- a/apps/frontend/src/utils/expectedOutputCalculators.ts
+++ b/apps/frontend/src/utils/expectedOutputCalculators.ts
@@ -57,7 +57,7 @@ export const createSwapOutputCalculator = (
     } else {
       // Show 1 SIMP = x ETH
       const rate = calculateExchangeRate(poolTokenReserve, poolEthReserve);
-      return `1 ${inputToken} ≈ ${rate.toFixed(6)} ${outputToken}`;
+      return `1 ${inputToken} ≈ ${rate.toFixed(4)} ${outputToken}`;
     }
   };
 
@@ -94,6 +94,6 @@ export const createSwapOutputCalculator = (
 
     // Convert back to display format
     const outputAmount = parseFloat(formatUnits(outputAmountWei, 18));
-    return `≈ ${outputAmount.toFixed(6)} ${outputToken}`;
+    return `≈ ${outputAmount.toFixed(4)} ${outputToken}`;
   };
 };

--- a/apps/frontend/src/utils/expectedOutputCalculators.ts
+++ b/apps/frontend/src/utils/expectedOutputCalculators.ts
@@ -15,13 +15,11 @@ export const createRemoveLiquidityOutputCalculator = (
   totalLPTokens: bigint
 ) => {
   return (lpAmountString: string): string => {
-    const lpAmount = parseFloat(lpAmountString);
-
-    if (!lpAmount || lpAmount <= 0 || totalLPTokens === 0n) {
+    if (!lpAmountString || lpAmountString === '0' || totalLPTokens === 0n) {
       return '0.0000 SIMP + 0.0000 ETH';
     }
 
-    const lpAmountWei = parseUnits(lpAmount.toString(), 18);
+    const lpAmountWei = parseUnits(lpAmountString, 18);
     const { ethAmount, tokenAmount } = calculateRemoveLiquidityOutput(
       lpAmountWei,
       poolEthReserve,
@@ -62,9 +60,7 @@ export const createSwapOutputCalculator = (
   };
 
   return (inputAmountString: string): string => {
-    const inputAmount = parseFloat(inputAmountString);
-
-    if (!inputAmount || inputAmount <= 0) {
+    if (!inputAmountString || inputAmountString === '0') {
       return getExchangeRate() || `≈ 0 ${outputToken}`;
     }
 
@@ -73,7 +69,7 @@ export const createSwapOutputCalculator = (
     }
 
     // Convert input to wei for calculation
-    const inputAmountWei = parseUnits(inputAmount.toString(), 18);
+    const inputAmountWei = parseUnits(inputAmountString, 18);
     let outputAmountWei: bigint;
 
     if (isEthToToken) {

--- a/apps/frontend/src/utils/slippageProtection.spec.ts
+++ b/apps/frontend/src/utils/slippageProtection.spec.ts
@@ -11,7 +11,7 @@ describe('slippageProtection', () => {
       const result = calculateMinAmountWithSlippage(expectedAmount);
 
       // 0.5% slippage = 99.5% of original
-      expect(result).toBe(BigInt(995e15));
+      expect(result).toBe(BigInt(0.995e18));
     });
 
     it('should apply custom slippage tolerance', () => {
@@ -23,7 +23,7 @@ describe('slippageProtection', () => {
       );
 
       // 1% slippage = 99% of original
-      expect(result).toBe(BigInt(990e15));
+      expect(result).toBe(BigInt(0.99e18));
     });
 
     it('should handle 5% slippage tolerance', () => {
@@ -35,7 +35,7 @@ describe('slippageProtection', () => {
       );
 
       // 5% slippage = 95% of original
-      expect(result).toBe(BigInt(950e15));
+      expect(result).toBe(BigInt(0.95e18));
     });
 
     it('should handle small amounts', () => {

--- a/apps/frontend/src/utils/slippageProtection.ts
+++ b/apps/frontend/src/utils/slippageProtection.ts
@@ -1,4 +1,8 @@
-import { ethers } from 'ethers';
+import {
+  calculateSwapOutput,
+  calculateAddLiquidityOutput,
+  calculateRemoveLiquidityOutput,
+} from './ammCalculations';
 
 /**
  * Default slippage tolerance percentage (0.5%)
@@ -7,9 +11,9 @@ export const DEFAULT_SLIPPAGE_TOLERANCE = 0.5;
 
 /**
  * Calculates the minimum amount out with slippage protection
- * @param expectedAmount - The expected output amount
+ * @param expectedAmount - The expected output amount in wei
  * @param slippageTolerancePercent - Slippage tolerance as percentage (e.g., 0.5 for 0.5%)
- * @returns Minimum amount with slippage protection applied
+ * @returns Minimum amount with slippage protection applied in wei
  */
 export const calculateMinAmountWithSlippage = (
   expectedAmount: bigint,
@@ -27,68 +31,51 @@ export const calculateMinAmountWithSlippage = (
  * Uses the same logic as the smart contract
  */
 export const calculateExpectedLPTokens = (
-  amountSimplest: number,
-  amountETH: number,
-  reserveSimplest: number,
-  reserveETH: number,
-  totalLPTokens: number
+  amountSimplest: bigint,
+  amountETH: bigint,
+  reserveSimplest: bigint,
+  reserveETH: bigint,
+  totalLPTokens: bigint
 ): bigint => {
-  if (totalLPTokens === 0) {
-    // First liquidity provision - use sqrt of product
-    const product =
-      BigInt(Math.floor(amountSimplest * 1e18)) *
-      BigInt(Math.floor(amountETH * 1e18));
-    return BigInt(Math.floor(Math.sqrt(Number(product))));
-  } else {
-    // Subsequent liquidity - use minimum of ratios
-    const simplestRatio = (amountSimplest * totalLPTokens) / reserveSimplest;
-    const ethRatio = (amountETH * totalLPTokens) / reserveETH;
-    const minRatio = Math.min(simplestRatio, ethRatio);
-    return ethers.parseEther(minRatio.toString());
-  }
+  return calculateAddLiquidityOutput(
+    amountSimplest,
+    amountETH,
+    reserveETH,
+    reserveSimplest,
+    totalLPTokens
+  );
 };
 
 /**
  * Calculates expected token amounts for removing liquidity
  */
 export const calculateExpectedRemovalAmounts = (
-  lpTokenAmount: number,
-  reserveSimplest: number,
-  reserveETH: number,
-  totalLPTokens: number
+  lpTokenAmount: bigint,
+  reserveSimplest: bigint,
+  reserveETH: bigint,
+  totalLPTokens: bigint
 ): { expectedSimplest: bigint; expectedETH: bigint } => {
-  if (totalLPTokens === 0) {
-    return { expectedSimplest: 0n, expectedETH: 0n };
-  }
-
-  const expectedSimplest = ethers.parseEther(
-    ((lpTokenAmount * reserveSimplest) / totalLPTokens).toString()
-  );
-  const expectedETH = ethers.parseEther(
-    ((lpTokenAmount * reserveETH) / totalLPTokens).toString()
+  const { tokenAmount, ethAmount } = calculateRemoveLiquidityOutput(
+    lpTokenAmount,
+    reserveETH,
+    reserveSimplest,
+    totalLPTokens
   );
 
-  return { expectedSimplest, expectedETH };
+  return {
+    expectedSimplest: tokenAmount,
+    expectedETH: ethAmount,
+  };
 };
 
 /**
  * Calculates expected swap output with 0.3% fee
- * Uses constant product formula: (reserveOut * amountIn * 997) / (reserveIn * 1000 + amountIn * 997)
+ * Uses centralized AMM calculation utility
  */
 export const calculateExpectedSwapOutput = (
-  amountIn: number,
-  reserveIn: number,
-  reserveOut: number
+  amountIn: bigint,
+  reserveIn: bigint,
+  reserveOut: bigint
 ): bigint => {
-  if (reserveIn === 0 || reserveOut === 0) {
-    return 0n;
-  }
-
-  // Apply 0.3% fee (997/1000)
-  const amountInWithFee = Math.floor(amountIn * 997);
-  const numerator = reserveOut * amountInWithFee;
-  const denominator = reserveIn * 1000 + amountInWithFee;
-  const expectedOutput = numerator / denominator;
-
-  return ethers.parseEther(expectedOutput.toString());
+  return calculateSwapOutput(amountIn, reserveIn, reserveOut);
 };


### PR DESCRIPTION
## Summary
Extracted scattered AMM calculations into a centralized utility and standardized BigInt usage for precision.

## Changes
- Created ammCalculations.ts utility for all AMM multiply rule calculations
- Updated components to use BigInt for wei amounts
- Standardized amountWei prop naming across input components
- Replaced unsafe Number() conversions with ethers utilities
- Added comprehensive test coverage

## Test plan
- [x] All tests pass
- [x] AMM calculations work correctly
- [x] BigInt precision maintained
- [x] No TypeScript/lint errors