### PR TITLE
Improve e2e test argument handling with transparent pass-through

### DIFF
--- a/apps/e2e/project.json
+++ b/apps/e2e/project.json
@@ -8,7 +8,7 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/dist/.playwright"],
       "options": {
-        "command": "./run-e2e.sh {args.file} {args.grep}",
+        "command": "./scripts/run-e2e.sh",
         "parallel": false,
         "cwd": "apps/e2e"
       }

--- a/apps/e2e/scripts/run-e2e.sh
+++ b/apps/e2e/scripts/run-e2e.sh
@@ -15,26 +15,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Process arguments
-TEST_FILES=""
-GREP_PATTERN=""
-
-for arg in "$@"; do
-    # Skip empty args that come from Nx parameter substitution
-    if [ -n "$arg" ] && [ "$arg" != "{args.file}" ] && [ "$arg" != "{args.grep}" ]; then
-        # Check if this looks like a grep pattern (starts with --grep)
-        if [[ "$arg" == "--grep="* ]]; then
-            GREP_PATTERN="$arg"
-        elif [ -z "$GREP_PATTERN" ] && [[ "$arg" != *.spec.ts ]] && [[ "$arg" != src/* ]]; then
-            # If no explicit --grep= and not a test file, treat as grep pattern
-            GREP_PATTERN="--grep=$arg"
-        else
-            # Assume it's a test file
-            TEST_FILES="$TEST_FILES $arg"
-        fi
-    fi
-done
-
 # Start synpress setup in parallel
 echo "Setting up synpress..."
 synpress &
@@ -61,6 +41,6 @@ wait $SYNPRESS_PID
 
 # Run tests
 echo "Running e2e tests..."
-npx playwright test --config=playwright.config.ts $GREP_PATTERN $TEST_FILES
+npx playwright test --config=playwright.config.ts "$@"
 
 echo "Tests completed"


### PR DESCRIPTION
## Summary
- Move run-e2e.sh to scripts/ folder for better organization
- Replace complex argument parsing with simple "$@" pass-through  
- Enable transparent Playwright CLI argument support (--grep, --file, etc.)
- Fix shell quoting issues that prevented grep filtering from working

## Test plan
- [x] Verify `nx test e2e --grep="pattern"` filters tests correctly
- [x] Verify `nx test e2e src/file.spec.ts` runs specific files
- [x] Verify all existing e2e functionality still works
- [x] Test argument pass-through with various Playwright CLI options