### PR TITLE
Change CI e2e-tests runner from macOS to Ubuntu Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
 
   e2e-tests:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
Change the GitHub Actions CI runner for e2e tests from `macos-latest` to `ubuntu-latest` for better cost efficiency and performance.

## Changes
- Updated `e2e-tests` job in `.github/workflows/ci.yml` to use `ubuntu-latest` instead of `macos-latest`
- Linux runners are typically faster and more cost-effective than macOS runners
- E2E tests should work consistently across both platforms

## Test plan
- [x] Verify workflow file syntax is correct
- [ ] Monitor next CI run to ensure e2e tests pass on Linux runner