### PR TITLE
Improve swap confirmation dialog and wallet info display

### DIFF
--- a/apps/e2e/src/amm-functionality.spec.ts
+++ b/apps/e2e/src/amm-functionality.spec.ts
@@ -33,7 +33,7 @@ test('should display AMM page with disabled elements before connection', async (
   });
 
   // Verify the account status shows as not connected
-  await expect(page.getByText('Your Account: Not Connected')).toBeVisible({
+  await expect(page.getByText('Connected Account: Not Connected')).toBeVisible({
     timeout: 10000,
   });
 
@@ -113,17 +113,9 @@ test.describe('AMM Functionality', () => {
         timeout: 10000,
       });
 
-      // Wait for the balance display to appear with both SIMP and ETH balances
-      await expect(page.locator('text=/^Balance:.*SIMP.*ETH/')).toBeVisible({
+      // Wait for the connected account to appear
+      await expect(page.getByText('Connected Account:')).toBeVisible({
         timeout: 15000,
-      });
-
-      // Verify the displayed balances match our expected initial balances
-      const currentBalances = balanceCalculator.getCurrentBalances();
-      const expectedBalanceText = `Balance: ${currentBalances.simpBalance.toFixed(4)} SIMP | ${currentBalances.ethBalance.toFixed(4)} ETH`;
-      const balanceElement = page.getByText('Balance:').locator('..');
-      await expect(balanceElement).toHaveText(expectedBalanceText, {
-        timeout: 10000,
       });
 
       // Take a screenshot of the connected state with initial balances
@@ -198,14 +190,8 @@ test.describe('AMM Functionality', () => {
       await expect(ethInput).toHaveValue('');
       await expect(simpInput).toHaveValue('');
 
-      // Update our balance tracker and verify the UI reflects the new balances
+      // Update our balance tracker
       balanceCalculator.addLiquidity(100, 2000, gasUsed);
-      const updatedBalances = balanceCalculator.getCurrentBalances();
-      const expectedBalanceText = `Balance: ${updatedBalances.simpBalance.toFixed(4)} SIMP | ${updatedBalances.ethBalance.toFixed(4)} ETH`;
-      const balanceElement = page.getByText('Balance:').locator('..');
-      await expect(balanceElement).toHaveText(expectedBalanceText, {
-        timeout: 10000,
-      });
 
       // Take a screenshot of the successful liquidity addition
       await argosScreenshot(page, 'add-liquidity-success');
@@ -296,14 +282,6 @@ test.describe('AMM Functionality', () => {
       // Update our balance tracker with the removal results and gas costs
       balanceCalculator.removeLiquidity(50, removeLiquidityGasUsed);
 
-      // Verify the UI displays the updated balances after liquidity removal
-      const removedBalances = balanceCalculator.getCurrentBalances();
-      const expectedBalanceText = `Balance: ${removedBalances.simpBalance.toFixed(4)} SIMP | ${removedBalances.ethBalance.toFixed(4)} ETH`;
-      const balanceElement = page.getByText('Balance:').locator('..');
-      await expect(balanceElement).toHaveText(expectedBalanceText, {
-        timeout: 10000,
-      });
-
       // Take a screenshot of the successful liquidity removal
       await argosScreenshot(page, 'remove-liquidity-success');
     };
@@ -344,6 +322,10 @@ test.describe('AMM Functionality', () => {
       const proceedButton = page.getByRole('button', { name: 'Proceed' });
       await expect(proceedButton).toBeVisible({ timeout: 5000 });
 
+      // Verify the confirmation dialog shows user-friendly text
+      await expect(page.getByText(/You'll pay:/)).toBeVisible();
+      await expect(page.getByText(/You'll receive:/)).toBeVisible();
+
       // Take a snapshot of the ETH to SIMP swap confirmation dialog
       await argosScreenshot(page, 'eth-to-simp-swap-confirm-dialog');
 
@@ -363,14 +345,6 @@ test.describe('AMM Functionality', () => {
       // Update our balance tracker with the swap results and gas costs
       // Using reverse calculation: we want 20 SIMP output
       balanceCalculator.buySimpWithEth(20, ethSwapGasUsed);
-
-      // Verify the UI displays the updated balances
-      const swapUpdatedBalances = balanceCalculator.getCurrentBalances();
-      const expectedBalanceText = `Balance: ${swapUpdatedBalances.simpBalance.toFixed(4)} SIMP | ${swapUpdatedBalances.ethBalance.toFixed(4)} ETH`;
-      const balanceElement = page.getByText('Balance:').locator('..');
-      await expect(balanceElement).toHaveText(expectedBalanceText, {
-        timeout: 10000,
-      });
 
       // Take a screenshot of the successful ETH → SIMP swap
       await argosScreenshot(page, 'swap-eth-to-simp-success');
@@ -415,6 +389,10 @@ test.describe('AMM Functionality', () => {
       const proceedButton = page.getByRole('button', { name: 'Proceed' });
       await expect(proceedButton).toBeVisible({ timeout: 5000 });
 
+      // Verify the confirmation dialog shows user-friendly text
+      await expect(page.getByText(/You'll pay:/)).toBeVisible();
+      await expect(page.getByText(/You'll receive:/)).toBeVisible();
+
       // Take a snapshot of the SIMP to ETH swap confirmation dialog
       await argosScreenshot(page, 'simp-to-eth-swap-confirm-dialog');
 
@@ -437,14 +415,6 @@ test.describe('AMM Functionality', () => {
       // Update our balance tracker with the swap results and gas costs
       // Using reverse calculation: we want 0.5 ETH output
       balanceCalculator.buyEthWithSimp(0.5, simpToEthGasUsed);
-
-      // Verify the UI displays the final balances after all transactions
-      const finalBalances = balanceCalculator.getCurrentBalances();
-      const expectedBalanceText = `Balance: ${finalBalances.simpBalance.toFixed(4)} SIMP | ${finalBalances.ethBalance.toFixed(4)} ETH`;
-      const balanceElement = page.getByText('Balance:').locator('..');
-      await expect(balanceElement).toHaveText(expectedBalanceText, {
-        timeout: 10000,
-      });
 
       // Take a screenshot of the successful SIMP → ETH swap
       await argosScreenshot(page, 'swap-simp-to-eth-success');

--- a/apps/frontend/src/components/ConnectedDashboard/ConnectedDashboard.spec.tsx
+++ b/apps/frontend/src/components/ConnectedDashboard/ConnectedDashboard.spec.tsx
@@ -12,11 +12,6 @@ vi.mock('../../utils/balances', () => ({
 }));
 
 // Mock the child components
-interface MockWalletInfoProps {
-  account: string;
-  ethBalance: number;
-  tokenBalance: number;
-}
 
 interface MockSwapProps {
   ammContract: unknown;
@@ -40,12 +35,8 @@ interface MockLiquidityProps {
 }
 
 vi.mock('../WalletInfo/WalletInfo', () => ({
-  WalletInfo: ({ account, ethBalance, tokenBalance }: MockWalletInfoProps) => (
-    <div data-testid="wallet-info">
-      {account
-        ? `${account} - ${ethBalance.toFixed(4)} ETH / ${tokenBalance.toFixed(4)} SIMP`
-        : 'Not Connected'}
-    </div>
+  WalletInfo: ({ account }: { account: string }) => (
+    <div data-testid="wallet-info">{account || 'Not Connected'}</div>
   ),
 }));
 
@@ -172,9 +163,7 @@ describe('ConnectedDashboard', () => {
       // Wait for async balance fetching to complete
       await waitFor(() => {
         expect(
-          screen.getByText(
-            /0x1234567890abcdef1234567890abcdef12345678 - 5\.0000 ETH \/ 1000\.0000 SIMP/
-          )
+          screen.getByText('0x1234567890abcdef1234567890abcdef12345678')
         ).toBeInTheDocument();
       });
     });
@@ -216,11 +205,9 @@ describe('ConnectedDashboard', () => {
 
       // Wait for async useEffect to complete (even though it does nothing with null signer)
       await waitFor(() => {
-        // Should show zero balances in WalletInfo and "Wallet not connected" for contracts
+        // Should show account in WalletInfo and "Wallet not connected" for contracts
         expect(
-          screen.getByText(
-            '0x1234567890abcdef1234567890abcdef12345678 - 0.0000 ETH / 0.0000 SIMP'
-          )
+          screen.getByText('0x1234567890abcdef1234567890abcdef12345678')
         ).toBeInTheDocument();
         expect(screen.getByText('Wallet not connected')).toBeInTheDocument();
       });
@@ -245,7 +232,9 @@ describe('ConnectedDashboard', () => {
       render(<ConnectedDashboard />);
 
       await waitFor(() => {
-        expect(screen.getByText(/1000\.0000 SIMP/)).toBeInTheDocument();
+        expect(
+          screen.getByText('0x1234567890abcdef1234567890abcdef12345678')
+        ).toBeInTheDocument();
       });
     });
   });

--- a/apps/frontend/src/components/ConnectedDashboard/ConnectedDashboard.tsx
+++ b/apps/frontend/src/components/ConnectedDashboard/ConnectedDashboard.tsx
@@ -4,11 +4,9 @@ import { WalletInfo, Swap, Liquidity } from '../';
 import { Token__factory, AMMPool__factory } from '@typechain-types';
 import { config } from '../../config';
 import {
-  getWalletBalances,
   getPoolReserves,
   ensureTokenSymbolIsSIMP,
   getLiquidityBalances,
-  WalletBalances,
   PoolReserves,
   LiquidityBalances,
 } from '../../utils/balances';
@@ -19,10 +17,6 @@ export const ConnectedDashboard = () => {
 
 const DashboardContent = () => {
   const { account, signer, ethereumProvider } = useWallet();
-  const [walletBalances, setWalletBalances] = useState<WalletBalances>({
-    ethBalance: 0,
-    tokenBalance: 0,
-  });
   const [poolReserves, setPoolReserves] = useState<PoolReserves>({
     ethReserve: 0n,
     tokenReserve: 0n,
@@ -36,7 +30,6 @@ const DashboardContent = () => {
   // Fetch all balances and token info
   const refreshAllBalances = useCallback(async () => {
     if (!signer || !ethereumProvider || !account) {
-      setWalletBalances({ ethBalance: 0, tokenBalance: 0 });
       setPoolReserves({ ethReserve: 0n, tokenReserve: 0n });
       setLpTokenBalances({
         userLPTokens: 0,
@@ -47,14 +40,12 @@ const DashboardContent = () => {
     }
 
     try {
-      const [walletBal, poolReserves, lpTokenBal] = await Promise.all([
-        getWalletBalances(ethereumProvider, account, signer),
+      const [poolReserves, lpTokenBal] = await Promise.all([
         getPoolReserves(signer),
         getLiquidityBalances(signer, account),
         ensureTokenSymbolIsSIMP(signer),
       ]);
 
-      setWalletBalances(walletBal);
       setPoolReserves(poolReserves);
       setLpTokenBalances(lpTokenBal);
     } catch (error) {
@@ -85,11 +76,7 @@ const DashboardContent = () => {
         gap: '0',
       }}
     >
-      <WalletInfo
-        account={account}
-        ethBalance={walletBalances.ethBalance}
-        tokenBalance={walletBalances.tokenBalance}
-      />
+      <WalletInfo account={account} />
 
       <ContractsSection
         poolEthReserve={poolReserves.ethReserve}

--- a/apps/frontend/src/components/ConnectedDashboard/ConnectedDashboard.tsx
+++ b/apps/frontend/src/components/ConnectedDashboard/ConnectedDashboard.tsx
@@ -10,6 +10,11 @@ import {
   PoolReserves,
   LiquidityBalances,
 } from '../../utils/balances';
+import { useErrorMessage } from '../../contexts/ErrorMessageContext';
+import {
+  getFriendlyMessage,
+  ERROR_OPERATIONS,
+} from '../../utils/errorMessages';
 
 export const ConnectedDashboard = () => {
   return <DashboardContent />;
@@ -17,6 +22,7 @@ export const ConnectedDashboard = () => {
 
 const DashboardContent = () => {
   const { account, signer, ethereumProvider } = useWallet();
+  const { setErrorMessage } = useErrorMessage();
   const [poolReserves, setPoolReserves] = useState<PoolReserves>({
     ethReserve: 0n,
     tokenReserve: 0n,
@@ -48,12 +54,13 @@ const DashboardContent = () => {
 
       setPoolReserves(poolReserves);
       setLpTokenBalances(lpTokenBal);
+      setErrorMessage(''); // Clear any previous errors on success
     } catch (error) {
-      console.error(
-        `Failed to fetch balances: ${error instanceof Error ? error.message : 'Unknown error'}`
+      setErrorMessage(
+        getFriendlyMessage(ERROR_OPERATIONS.BALANCE_FETCH, error)
       );
     }
-  }, [signer, ethereumProvider, account]);
+  }, [signer, ethereumProvider, account, setErrorMessage]);
 
   // Initial load
   useEffect(() => {

--- a/apps/frontend/src/components/Liquidity/RemoveLiquidity.spec.tsx
+++ b/apps/frontend/src/components/Liquidity/RemoveLiquidity.spec.tsx
@@ -160,7 +160,9 @@ describe('RemoveLiquidity', () => {
     // Wait for confirmation dialog and click confirm
     await waitFor(() => {
       const confirmButton = getByRole('button', { name: 'Remove' });
-      fireEvent.click(confirmButton);
+      act(() => {
+        fireEvent.click(confirmButton);
+      });
     });
 
     await waitFor(() => {
@@ -198,7 +200,9 @@ describe('RemoveLiquidity', () => {
     // Wait for confirmation dialog and click cancel
     await waitFor(() => {
       const cancelButton = getByRole('button', { name: 'Cancel' });
-      fireEvent.click(cancelButton);
+      act(() => {
+        fireEvent.click(cancelButton);
+      });
     });
 
     // Dialog should be closed
@@ -238,6 +242,11 @@ describe('RemoveLiquidity', () => {
       resolveDialog([BigInt(5e18), BigInt(2.5e18)]);
     });
 
+    // Wait for dialog to appear after promise resolution
+    await waitFor(() => {
+      expect(getByRole('button', { name: 'Remove' })).toBeTruthy();
+    });
+
     // Now test loading state during transaction execution
     const { promise: txPromise, resolve: resolveTx } =
       createDeferredTransactionPromise();
@@ -246,7 +255,9 @@ describe('RemoveLiquidity', () => {
     // Wait for dialog and click confirm
     await waitFor(() => {
       const confirmButton = getByRole('button', { name: 'Remove' });
-      fireEvent.click(confirmButton);
+      act(() => {
+        fireEvent.click(confirmButton);
+      });
     });
 
     // Should show loading state during transaction
@@ -257,6 +268,11 @@ describe('RemoveLiquidity', () => {
     // Clean up
     act(() => {
       resolveTx();
+    });
+
+    // Wait for transaction to complete and state to settle
+    await waitFor(() => {
+      expect(getByRole('button', { name: 'Remove Liquidity' })).toBeTruthy();
     });
   });
 
@@ -309,7 +325,9 @@ describe('RemoveLiquidity', () => {
     // Wait for confirmation dialog and click confirm
     await waitFor(() => {
       const confirmButton = getByRole('button', { name: 'Remove' });
-      fireEvent.click(confirmButton);
+      act(() => {
+        fireEvent.click(confirmButton);
+      });
     });
 
     await waitFor(() => {

--- a/apps/frontend/src/components/NotConnectedDashboard/NotConnectedDashboard.tsx
+++ b/apps/frontend/src/components/NotConnectedDashboard/NotConnectedDashboard.tsx
@@ -12,7 +12,7 @@ export const NotConnectedDashboard = () => {
         gap: '0',
       }}
     >
-      <WalletInfo account={account} ethBalance={0} tokenBalance={0} />
+      <WalletInfo account={account} />
       <DisabledSwap />
       <DisabledLiquidity />
     </div>

--- a/apps/frontend/src/components/Swap/Swap.spec.tsx
+++ b/apps/frontend/src/components/Swap/Swap.spec.tsx
@@ -398,6 +398,29 @@ describe('Swap Component', () => {
       // Swap should not have been called
       expect(mockAmmContract.swap).not.toHaveBeenCalled();
     });
+
+    it('should display user-friendly confirmation dialog text', async () => {
+      mockAmmContract.getSwapOutput.mockResolvedValue(BigInt(1e18));
+
+      render(<Swap {...defaultProps} />);
+
+      // Test ETH to Token swap confirmation text
+      const input = screen.getByPlaceholderText('Get SIMP');
+      fireEvent.change(input, { target: { value: '1.0' } });
+
+      const swapButton = screen.getByText('Buy SIMP with ETH');
+      fireEvent.click(swapButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('Swap Confirmation')).toBeInTheDocument();
+      });
+
+      // Check for user-friendly text instead of technical terms
+      expect(screen.getByText(/You'll pay:/)).toBeInTheDocument();
+      expect(screen.getByText(/You'll receive:/)).toBeInTheDocument();
+      expect(screen.queryByText(/Required Input:/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Expected Output:/)).not.toBeInTheDocument();
+    });
   });
 
   describe('Edge Cases', () => {

--- a/apps/frontend/src/components/Swap/Swap.tsx
+++ b/apps/frontend/src/components/Swap/Swap.tsx
@@ -207,20 +207,17 @@ export const Swap = ({
         cancelText="Cancel"
       >
         <div>
-          <p>
-            <strong>Swap Details:</strong>
-          </p>
           {swapDirection === 'eth-to-token' ? (
             <>
               <p>
-                Required Input:{' '}
+                You'll pay:{' '}
                 {parseFloat(ethers.formatEther(calculatedInputAmount)).toFixed(
                   4
                 )}{' '}
                 ETH
               </p>
               <p>
-                Expected Output:{' '}
+                You'll receive:{' '}
                 {parseFloat(ethers.formatEther(desiredOutputAmount)).toFixed(4)}{' '}
                 SIMP
               </p>
@@ -228,14 +225,14 @@ export const Swap = ({
           ) : (
             <>
               <p>
-                Required Input:{' '}
+                You'll pay:{' '}
                 {parseFloat(ethers.formatEther(calculatedInputAmount)).toFixed(
                   4
                 )}{' '}
                 SIMP
               </p>
               <p>
-                Expected Output:{' '}
+                You'll receive:{' '}
                 {parseFloat(ethers.formatEther(desiredOutputAmount)).toFixed(4)}{' '}
                 ETH
               </p>

--- a/apps/frontend/src/components/WalletInfo/WalletInfo.spec.tsx
+++ b/apps/frontend/src/components/WalletInfo/WalletInfo.spec.tsx
@@ -4,8 +4,6 @@ import { WalletInfo } from './WalletInfo';
 
 const defaultProps = {
   account: '0x1234567890abcdef1234567890abcdef12345678',
-  ethBalance: 5.123456789,
-  tokenBalance: 1000.987654321,
 };
 
 describe('WalletInfo', () => {
@@ -14,20 +12,9 @@ describe('WalletInfo', () => {
       render(<WalletInfo {...defaultProps} />);
 
       expect(
-        screen.getByText('Account:', { exact: false })
+        screen.getByText('Connected Account:', { exact: false })
       ).toBeInTheDocument();
       expect(screen.getByText(defaultProps.account)).toBeInTheDocument();
-      expect(
-        screen.getByText('Balance:', { exact: false })
-      ).toBeInTheDocument();
-    });
-
-    it('should display formatted balances with correct precision', () => {
-      render(<WalletInfo {...defaultProps} />);
-
-      // Should show 4 decimal places for both token and ETH balances
-      expect(screen.getByText(/1000\.9877 SIMP/)).toBeInTheDocument();
-      expect(screen.getByText(/5\.1235 ETH/)).toBeInTheDocument();
     });
   });
 
@@ -40,36 +27,20 @@ describe('WalletInfo', () => {
     });
   });
 
-  describe('Token Symbol', () => {
-    it('should display SIMP token symbol', () => {
-      render(<WalletInfo {...defaultProps} />);
-
-      expect(screen.getByText(/SIMP/)).toBeInTheDocument();
-    });
-  });
-
   describe('Disconnected State', () => {
-    it('should show "not connected" for both account and balance when account is empty', () => {
+    it('should show "not connected" when account is empty', () => {
       render(<WalletInfo {...defaultProps} account="" />);
 
-      // Should show labels
+      // Should show label
       expect(
-        screen.getByText('Account:', { exact: false })
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText('Balance:', { exact: false })
+        screen.getByText('Connected Account:', { exact: false })
       ).toBeInTheDocument();
 
-      // Should show "Not Connected" and "N/A" for account and balance respectively
+      // Should show "Not Connected"
       expect(screen.getByText('Not Connected')).toBeInTheDocument();
-      expect(screen.getByText('N/A')).toBeInTheDocument();
 
-      // Should not show actual account or balance values
+      // Should not show actual account value
       expect(screen.queryByText(defaultProps.account)).not.toBeInTheDocument();
-      expect(screen.queryByText(/SIMP/)).not.toBeInTheDocument();
-      expect(screen.queryByText(/ETH/)).not.toBeInTheDocument();
-      expect(screen.queryByText(/1000\.9877/)).not.toBeInTheDocument();
-      expect(screen.queryByText(/5\.1235/)).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/frontend/src/components/WalletInfo/WalletInfo.tsx
+++ b/apps/frontend/src/components/WalletInfo/WalletInfo.tsx
@@ -2,25 +2,13 @@ import styles from './WalletInfo.module.scss';
 
 interface WalletInfoProps {
   account: string;
-  ethBalance: number;
-  tokenBalance: number;
 }
 
-export const WalletInfo = ({
-  account,
-  ethBalance,
-  tokenBalance,
-}: WalletInfoProps) => {
+export const WalletInfo = ({ account }: WalletInfoProps) => {
   return (
     <div className={styles.walletInfo}>
       <p>
-        <strong>Your Account:</strong> {account || 'Not Connected'}
-      </p>
-      <p>
-        <strong>Balance:</strong>{' '}
-        {account
-          ? `${tokenBalance.toFixed(4)} SIMP | ${ethBalance.toFixed(4)} ETH`
-          : 'N/A'}
+        <strong>Connected Account:</strong> {account || 'Not Connected'}
       </p>
     </div>
   );

--- a/apps/frontend/src/utils/errorMessages.ts
+++ b/apps/frontend/src/utils/errorMessages.ts
@@ -12,6 +12,7 @@ export const ERROR_OPERATIONS = {
   ADD_LIQUIDITY: 'Add liquidity',
   REMOVE_LIQUIDITY: 'Remove liquidity',
   WALLET_CONNECTION: 'Wallet connection',
+  BALANCE_FETCH: 'Balance fetch',
 } as const;
 
 export type ErrorOperation =


### PR DESCRIPTION
## Summary
- Replace technical terms with user-friendly language in swap confirmation dialog
- Remove redundant balance display from wallet info component 
- Update account label for better clarity

## Changes
- Change 'Required Input' to 'You'll pay' and 'Expected Output' to 'You'll receive'
- Remove balance display from WalletInfo (already shown in wallet)
- Update 'Your Account' to 'Connected Account' 
- Update all unit and e2e tests to match new UI text