### PR TITLE
Fix Dependabot deployment workflow authentication error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   deploy:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Skip deployment job when triggered by Dependabot to prevent authentication errors.

- Add `if: github.actor \!= 'dependabot[bot]'` condition to deploy job
- Prevents GCP authentication failures when Dependabot lacks secret access