### PR TITLE
Add Playwright browser installation to e2e script

### DIFF
--- a/apps/e2e/scripts/run-e2e.sh
+++ b/apps/e2e/scripts/run-e2e.sh
@@ -18,6 +18,10 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Install Playwright browsers if needed
+echo "Installing Playwright browsers..."
+pnpm exec playwright install
+
 # Start synpress setup in parallel
 echo "Setting up synpress..."
 pnpm exec synpress &


### PR DESCRIPTION
Automatically install Playwright browsers before running e2e tests to prevent missing Chromium errors.

- Add `pnpm exec playwright install` to run-e2e.sh
- Ensures browsers are available after clean installs