### PR TITLE
Improve wallet error handling for user rejections

### DIFF
--- a/apps/frontend/src/contexts/WalletContext.spec.tsx
+++ b/apps/frontend/src/contexts/WalletContext.spec.tsx
@@ -209,7 +209,7 @@ describe('WalletContext', () => {
         expect(screen.getByTestId('signer')).toHaveTextContent('null');
         expect(screen.getByTestId('account')).toHaveTextContent('');
         expect(screen.getByTestId('errorMessage')).toHaveTextContent(
-          'Wallet connection failed: User rejected the request'
+          'Wallet connection cancelled: You rejected the request in your wallet.'
         );
       });
     });
@@ -474,7 +474,7 @@ describe('WalletContext', () => {
 
       await waitFor(() => {
         expect(screen.getByTestId('errorMessage')).toHaveTextContent(
-          'Wallet connection failed: User rejected the request'
+          'Wallet connection cancelled: You rejected the request in your wallet.'
         );
       });
 

--- a/apps/frontend/src/utils/errorMessages.spec.ts
+++ b/apps/frontend/src/utils/errorMessages.spec.ts
@@ -76,6 +76,60 @@ describe('errorMessages', () => {
       });
     });
 
+    describe('User rejection errors', () => {
+      it('should handle MetaMask user rejection with code 4001', () => {
+        const error = {
+          code: 4001,
+          message: 'User rejected the request.',
+        };
+
+        const result = getFriendlyMessage(
+          ERROR_OPERATIONS.WALLET_CONNECTION,
+          error
+        );
+
+        expect(result).toBe(
+          'Wallet connection cancelled: You rejected the request in your wallet.'
+        );
+      });
+
+      it('should handle user rejection by message content', () => {
+        const error = new Error('User rejected the request');
+
+        const result = getFriendlyMessage(ERROR_OPERATIONS.SWAP, error);
+
+        expect(result).toBe(
+          'Swap cancelled: You rejected the request in your wallet.'
+        );
+      });
+
+      it('should handle user denied message', () => {
+        const error = new Error('User denied transaction signature');
+
+        const result = getFriendlyMessage(
+          ERROR_OPERATIONS.ADD_LIQUIDITY,
+          error
+        );
+
+        expect(result).toBe(
+          'Add liquidity cancelled: You rejected the request in your wallet.'
+        );
+      });
+
+      it('should handle user cancelled message', () => {
+        const error = new Error('User cancelled the operation');
+
+        const result = getFriendlyMessage(
+          ERROR_OPERATIONS.REMOVE_LIQUIDITY,
+          error
+        );
+
+        expect(result).toBe(
+          'Remove liquidity cancelled: You rejected the request in your wallet.'
+        );
+      });
+    });
+
     describe('Operation types', () => {
       it('should prepend different operation types', () => {
         const error = new Error('Failed');


### PR DESCRIPTION
## Summary
- Add user-friendly error messages for wallet rejection (code 4001)
- Replace technical stack traces with clear "cancelled" messages  
- Update tests to reflect new error message format

## Test plan  
- Run frontend tests to verify error handling works correctly
- Test wallet connection rejection scenarios manually